### PR TITLE
./minishell -c commandに対応

### DIFF
--- a/srcs/main.c
+++ b/srcs/main.c
@@ -6,7 +6,7 @@
 /*   By: myokono <myokono@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/27 19:12:06 by myokono           #+#    #+#             */
-/*   Updated: 2025/02/27 19:20:40 by myokono          ###   ########.fr       */
+/*   Updated: 2025/02/28 21:13:59 by myokono          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -109,10 +109,15 @@ int	main(int argc, char **argv, char **envp)
 	t_shell	*shell;
 	char	*input;
 
-	(void)argc;
-	(void)argv;
 	shell = init_shell(envp);
 	setup_signals();
+	if (argc >= 3 && ft_strcmp(argv[1], "-c") == 0)
+	{
+		process_input(ft_strdup(argv[2]), shell);
+		free_shell(shell);
+		clear_history();
+		return (shell->exit_status);
+	}
 	while (shell->running)
 	{
 		input = readline("minishell$ ");


### PR DESCRIPTION
```
(base) mai-kac@maiMacBook 42tokyo_minishell_re % bash -c ls
Makefile	includes	minishell
README.md	libft		srcs
(base) mai-kac@maiMacBook 42tokyo_minishell_re % bash -c ls -la
Makefile	includes	minishell
README.md	libft		srcs
(base) mai-kac@maiMacBook 42tokyo_minishell_re % ls -la
total 128
drwxr-xr-x   9 mai-kac  staff    288  2 28 21:12 .
drwxr-xr-x  13 mai-kac  staff    416  2 27 15:49 ..
drwxr-xr-x  15 mai-kac  staff    480  2 28 20:58 .git
-rw-r--r--   1 mai-kac  staff   2490  2 27 12:03 Makefile
-rw-r--r--   1 mai-kac  staff     22  2 27 13:43 README.md
drwxr-xr-x   3 mai-kac  staff     96  2 27 11:53 includes
drwxr-xr-x  74 mai-kac  staff   2368  2 28 21:05 libft
-rwxr-xr-x   1 mai-kac  staff  55128  2 28 21:12 minishell
drwxr-xr-x   9 mai-kac  staff    288  2 28 21:12 srcs
```
の挙動を元に実装した。
- コマンドライン引数の数が3以上でも3の時と同じ挙動になる。
- オプションはなかったことにされる。