### PR TITLE
signal(Ctrl+C, Ctrl+D, Ctrl+\)の修正とリファクタリング

### DIFF
--- a/srcs/signals/signals.c
+++ b/srcs/signals/signals.c
@@ -12,53 +12,43 @@
 
 #include "../../includes/minishell.h"
 
-/**
- * SIGINT (Ctrl+C) シグナルハンドラ
- * @param sig シグナル番号
- */
 void	handle_sigint(int sig)
 {
 	(void)sig;
 	g_signal_status = 1;
-	write(STDOUT_FILENO, "\n", 1);
+	write(STDOUT_FILENO, "minishell$^C\n", 13);
 	rl_on_new_line();
 	rl_redisplay();
 }
 
-/**
- * SIGQUIT (Ctrl+\) シグナルハンドラ
- * @param sig シグナル番号
- */
 void	handle_sigquit(int sig)
 {
+	int	point_pos;
+	int	cursor_pos;
+
 	(void)sig;
-	/* 要件に従って何もしない */
+	point_pos = rl_point;
+	cursor_pos = rl_point;
+	rl_on_new_line();
+	rl_point = point_pos;
+	rl_redisplay();
 }
 
-/**
- * 子プロセスのシグナルハンドラ設定
- */
 void	setup_child_signals(void)
 {
 	signal(SIGINT, SIG_DFL);
 	signal(SIGQUIT, SIG_DFL);
 }
 
-/**
- * シグナルハンドラの設定
- */
 void	setup_signals(void)
 {
 	struct sigaction	sa_int;
 	struct sigaction	sa_quit;
 
-	/* SIGINT (Ctrl+C) ハンドラの設定 */
 	sa_int.sa_handler = handle_sigint;
 	sa_int.sa_flags = 0;
 	sigemptyset(&sa_int.sa_mask);
 	sigaction(SIGINT, &sa_int, NULL);
-
-	/* SIGQUIT (Ctrl+\) ハンドラの設定 */
 	sa_quit.sa_handler = handle_sigquit;
 	sa_quit.sa_flags = 0;
 	sigemptyset(&sa_quit.sa_mask);


### PR DESCRIPTION
- Ctrl+C：^Cを表示して改行minishell$の表示に戻る
- Ctrl+D：exitする
- Ctrl+\：何も表示しない