### PR TITLE
親プロセスでシグナルを無視、子プロセスでデフォルトのシグナル受付になるように変更しました

### DIFF
--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   minishell.h                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: myokono <myokono@student.42tokyo.jp>       +#+  +:+       +#+        */
+/*   By: ryabuki <ryabuki@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/01 00:00:00 by user              #+#    #+#             */
-/*   Updated: 2025/04/04 17:51:28 by myokono          ###   ########.fr       */
+/*   Updated: 2025/04/06 15:00:15 by ryabuki          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -150,6 +150,9 @@ int		builtin_exit(t_command *cmd, t_shell *shell);
 void	setup_signals(void);
 void	handle_sigint(int sig);
 void	handle_sigquit(int sig);
+void	ignore_signals(void);
+void	setup_child_signals(void);
+void	defalut_signals(void);
 
 /* エラーハンドリング */
 void	error_message(char *msg);

--- a/srcs/executor/executor.c
+++ b/srcs/executor/executor.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   executor.c                                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: myokono <myokono@student.42tokyo.jp>       +#+  +:+       +#+        */
+/*   By: ryabuki <ryabuki@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/01 00:00:00 by user              #+#    #+#             */
-/*   Updated: 2025/04/04 18:12:33 by myokono          ###   ########.fr       */
+/*   Updated: 2025/04/06 15:15:37 by ryabuki          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -48,6 +48,7 @@ int	execute_external_standalone(t_command *cmd, t_shell *shell)
 		return (127);
 	}
 
+	ignore_signals();
 	pid = fork();
 	if (pid == -1)
 	{
@@ -69,7 +70,8 @@ int	execute_external_standalone(t_command *cmd, t_shell *shell)
 			dup2(cmd->output_fd, STDOUT_FILENO);
 			close(cmd->output_fd);
 		}
-
+		defalut_signals();
+		setup_child_signals();
 		execve(exec_path, cmd->args, shell->env_array);
 
 		// execve 失敗時
@@ -84,8 +86,11 @@ int	execute_external_standalone(t_command *cmd, t_shell *shell)
 	if (WIFEXITED(status))
 		return (WEXITSTATUS(status));
 	else if (WIFSIGNALED(status))
+	{
+		if (WTERMSIG(status) == SIGINT)
+			write(STDOUT_FILENO, "\n", 1);
 		return (128 + WTERMSIG(status));
-
+	}
 	return (1);
 }
 

--- a/srcs/executor/pipe.c
+++ b/srcs/executor/pipe.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   pipe.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: myokono <myokono@student.42tokyo.jp>       +#+  +:+       +#+        */
+/*   By: ryabuki <ryabuki@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/27 12:23:15 by myokono           #+#    #+#             */
-/*   Updated: 2025/04/04 17:42:21 by myokono          ###   ########.fr       */
+/*   Updated: 2025/04/06 15:06:13 by ryabuki          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -59,6 +59,7 @@ int	setup_pipes(t_command *commands)
  */
 void	setup_child_io(t_command *cmd)
 {
+	setup_child_signals();
 	/* 入力リダイレクトを設定 */
 	if (cmd->input_fd != STDIN_FILENO)
 	{
@@ -100,6 +101,7 @@ int	execute_pipeline(t_command *commands, t_shell *shell)
 		}
 
 		pid = fork();
+		ignore_signals();
 		if (pid == -1)
 		{
 			system_error("fork");
@@ -109,6 +111,7 @@ int	execute_pipeline(t_command *commands, t_shell *shell)
 		if (pid == 0)
 		{
 			/* 子プロセス */
+			defalut_signals();
 			setup_child_io(current);
 			
 			if (is_builtin(current->args[0]))

--- a/srcs/signals/signals.c
+++ b/srcs/signals/signals.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   signals.c                                          :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: yabukirento <yabukirento@student.42.fr>    +#+  +:+       +#+        */
+/*   By: ryabuki <ryabuki@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/01 00:00:00 by user              #+#    #+#             */
-/*   Updated: 2025/04/04 19:22:46 by yabukirento      ###   ########.fr       */
+/*   Updated: 2025/04/06 15:11:37 by ryabuki          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,6 +17,7 @@ void	handle_sigint(int sig)
 	(void)sig;
 	g_signal_status = 1;
 	write(STDOUT_FILENO, "\n", 1);
+	rl_on_new_line();
 	rl_replace_line("", 0);
 	rl_redisplay();
 }
@@ -29,7 +30,38 @@ void	handle_sigquit(int sig)
 	point_pos = rl_point;
 	rl_on_new_line();
 	rl_point = point_pos;
+	rl_replace_line("", 0);
 	rl_redisplay();
+}
+
+void	ignore_signals(void)
+{
+	struct sigaction	sa_int;
+	struct sigaction	sa_quit;
+
+	sa_int.sa_handler = SIG_IGN;
+	sa_int.sa_flags = SA_RESTART | SA_SIGINFO;;
+	sigemptyset(&sa_int.sa_mask);
+	sigaction(SIGINT, &sa_int, NULL);
+	sa_quit.sa_handler = SIG_IGN;
+	sa_quit.sa_flags = SA_RESTART | SA_SIGINFO;;
+	sigemptyset(&sa_quit.sa_mask);
+	sigaction(SIGQUIT, &sa_quit, NULL);
+}
+
+void	defalut_signals(void)
+{
+	struct sigaction	sa_int;
+	struct sigaction	sa_quit;
+
+	sa_int.sa_handler = SIG_DFL;
+	sa_int.sa_flags = SA_RESTART | SA_SIGINFO;;
+	sigemptyset(&sa_int.sa_mask);
+	sigaction(SIGINT, &sa_int, NULL);
+	sa_quit.sa_handler = SIG_DFL;
+	sa_quit.sa_flags = SA_RESTART | SA_SIGINFO;;
+	sigemptyset(&sa_quit.sa_mask);
+	sigaction(SIGQUIT, &sa_quit, NULL);
 }
 
 void	setup_child_signals(void)
@@ -44,11 +76,11 @@ void	setup_signals(void)
 	struct sigaction	sa_quit;
 
 	sa_int.sa_handler = handle_sigint;
-	sa_int.sa_flags = 0;
+	sa_int.sa_flags = SA_RESTART | SA_SIGINFO;;
 	sigemptyset(&sa_int.sa_mask);
 	sigaction(SIGINT, &sa_int, NULL);
 	sa_quit.sa_handler = handle_sigquit;
-	sa_quit.sa_flags = 0;
+	sa_quit.sa_flags = SA_RESTART | SA_SIGINFO;;
 	sigemptyset(&sa_quit.sa_mask);
 	sigaction(SIGQUIT, &sa_quit, NULL);
 }


### PR DESCRIPTION
This pull request includes several updates to signal handling and author information in the `minishell` project. The most significant changes involve adding new signal handling functions and updating the author information in multiple files.

### Signal Handling Improvements:

* [`includes/minishell.h`](diffhunk://#diff-29c141a418b83334b1dd8ff9066c9fb218e84e274d4381095f6aecb05b8fc5daR153-R155): Added declarations for new signal handling functions `ignore_signals`, `setup_child_signals`, and `defalut_signals`.
* [`srcs/executor/executor.c`](diffhunk://#diff-ab85f2c8376cece4cc4234c7fc86e185e8ca5cd1dde4cf52c37898718e76bc03R51): Integrated new signal handling functions `ignore_signals`, `setup_child_signals`, and `defalut_signals` into the `execute_external_standalone` function. [[1]](diffhunk://#diff-ab85f2c8376cece4cc4234c7fc86e185e8ca5cd1dde4cf52c37898718e76bc03R51) [[2]](diffhunk://#diff-ab85f2c8376cece4cc4234c7fc86e185e8ca5cd1dde4cf52c37898718e76bc03L72-R74) [[3]](diffhunk://#diff-ab85f2c8376cece4cc4234c7fc86e185e8ca5cd1dde4cf52c37898718e76bc03R89-R93)
* [`srcs/executor/pipe.c`](diffhunk://#diff-3e38d452289736e99002c28d193ac5b7092f761d9d7c679ba0d81681f154883dR62): Updated `setup_child_io` and `execute_pipeline` functions to include calls to `setup_child_signals`, `ignore_signals`, and `defalut_signals`. [[1]](diffhunk://#diff-3e38d452289736e99002c28d193ac5b7092f761d9d7c679ba0d81681f154883dR62) [[2]](diffhunk://#diff-3e38d452289736e99002c28d193ac5b7092f761d9d7c679ba0d81681f154883dR104) [[3]](diffhunk://#diff-3e38d452289736e99002c28d193ac5b7092f761d9d7c679ba0d81681f154883dR114)
* [`srcs/signals/signals.c`](diffhunk://#diff-077ba7d0022629545541fbe5f844a2d69f8098d8d4890d4f1e77955caff7ff3aR33-R66): Added implementations for `ignore_signals` and `defalut_signals` functions, and updated `setup_signals` function to use `SA_RESTART | SA_SIGINFO` flags. [[1]](diffhunk://#diff-077ba7d0022629545541fbe5f844a2d69f8098d8d4890d4f1e77955caff7ff3aR33-R66) [[2]](diffhunk://#diff-077ba7d0022629545541fbe5f844a2d69f8098d8d4890d4f1e77955caff7ff3aL47-R83)

### Author Information Updates:

* Updated author information in the headers of `includes/minishell.h`, `srcs/executor/executor.c`, `srcs/executor/pipe.c`, and `srcs/signals/signals.c` to reflect the new author `ryabuki`. [[1]](diffhunk://#diff-29c141a418b83334b1dd8ff9066c9fb218e84e274d4381095f6aecb05b8fc5daL6-R9) [[2]](diffhunk://#diff-ab85f2c8376cece4cc4234c7fc86e185e8ca5cd1dde4cf52c37898718e76bc03L6-R9) [[3]](diffhunk://#diff-3e38d452289736e99002c28d193ac5b7092f761d9d7c679ba0d81681f154883dL6-R9) [[4]](diffhunk://#diff-077ba7d0022629545541fbe5f844a2d69f8098d8d4890d4f1e77955caff7ff3aL6-R9)- 子プロセスが発生するとき、親プロセスでシグナルを無視、子プロセスでシグナルをデフォルト操作になるように変更しました
- 上記の際に親プロセス側で子プロセスがシグナルにより終了したことを認識し、適切に改行が行われるように変更しました