### PR TITLE
Integrated tester

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@
 #                                                         :::      ::::::::    #
 #    Makefile                                           :+:      :+:    :+:    #
 #                                                     +:+ +:+         +:+      #
-#    By: myokono <myokono@student.42tokyo.jp>       +#+  +:+       +#+         #
+#    By: ryabuki <ryabuki@student.42.fr>            +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2023/01/01 00:00:00 by user              #+#    #+#              #
-#    Updated: 2025/04/06 14:29:28 by myokono          ###   ########.fr        #
+#    Updated: 2025/04/06 16:04:48 by ryabuki          ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -73,6 +73,11 @@ $(LIBFT):
 $(NAME): $(LIBFT) $(OBJS)
 	$(CC) $(CFLAGS) $(OBJS) $(INCLUDES) $(LIBS) -o $(NAME)
 	@echo "$(NAME) has been created!"
+
+test: $(NAME)
+	@echo "Running tests..."
+	@bash ./mytester.sh
+	@echo "Tests completed!"
 
 clean:
 	$(MAKE) -C ./libft clean

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,7 +6,7 @@
 /*   By: ryabuki <ryabuki@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/01 00:00:00 by user              #+#    #+#             */
-/*   Updated: 2025/04/06 15:00:15 by ryabuki          ###   ########.fr       */
+/*   Updated: 2025/04/06 16:02:15 by ryabuki          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -162,5 +162,6 @@ void	system_error(char *prefix);
 /* メモリ管理 */
 void	*safe_malloc(size_t size);
 void	free_array(char **array);
+void	free_env_list(t_env *env_list);
 
 #endif

--- a/mytester.sh
+++ b/mytester.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+MINISHELL=./minishell
+REF_SHELL=/bin/bash
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+RESET='\033[0m'
+
+test_cases=(
+  # === BUILTINS ===
+  'echo hello world'
+  'echo -n "no newline"'
+  'pwd'
+  'export FOO=bar'
+  'echo $FOO'
+  'unset FOO'
+  'echo $FOO'
+  'env | grep PATH'
+
+  # === CD ===
+  'pwd'
+  'cd /'
+  'pwd'
+  'cd -'  # may fail if OLDPWD unset
+
+  # === PIPES ===
+  'echo hello | cat'
+  'ls | grep minishell'
+
+  # === REDIRECTIONS ===
+  'echo test > out.txt'
+  'cat < out.txt'
+  'echo more >> out.txt'
+  'cat < out.txt'
+  'rm out.txt'
+
+  # === QUOTES ===
+  'echo "double quoted $USER"'
+  "echo 'single quoted $USER'"
+  "echo 'nested \"quote\" test'"
+
+  # === VARIABLES ===
+  'export VAR=hello'
+  'echo $VAR'
+  'unset VAR'
+  'echo $VAR'
+
+  # === SYNTAX ERRORS ===
+  '|'
+  'echo hello | | cat'
+  'cat <'
+  'echo >'
+
+  # === EXIT ===
+  'exit'
+)
+
+filter_output() {
+  sed '/^minishell\$ /d' |          # プロンプト行そのものを削除
+  sed 's/minishell\$//g' |          # 行末にくっついた minishell$ を削除
+  sed '/^exit$/d' |                 # exit 単体行を削除
+  sed '/^ *$/d'                     # 空白だけの行も削除（任意）
+}
+
+run_test() {
+  local input="$1"
+  local expected result
+
+  expected=$(echo "$input" | $REF_SHELL 2>&1 | filter_output)
+  result=$(echo "$input" | $MINISHELL 2>&1 | filter_output)
+
+  if [ "$expected" = "$result" ]; then
+    echo -e "✅ ${GREEN}$input${RESET}"
+  else
+    echo -e "❌ ${RED}$input${RESET}"
+    echo "   expected: $expected"
+    echo "   got     : $result"
+  fi
+}
+
+
+echo "🚀 Running minishell tester..."
+
+for test in "${test_cases[@]}"; do
+  run_test "$test"
+done
+echo "✅ All tests completed."

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   main.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: myokono <myokono@student.42tokyo.jp>       +#+  +:+       +#+        */
+/*   By: ryabuki <ryabuki@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/27 19:12:06 by myokono           #+#    #+#             */
-/*   Updated: 2025/04/06 14:27:27 by myokono          ###   ########.fr       */
+/*   Updated: 2025/04/06 16:11:55 by ryabuki          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -113,7 +113,6 @@ int	main(int argc, char **argv, char **envp)
 {
 	t_shell	*shell;
 	int		status;
-
 	setup_signals();
 	shell = init_shell(envp);
 	if (!shell)

--- a/srcs/utils/env_init.c
+++ b/srcs/utils/env_init.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   env_init.c                                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: myokono <myokono@student.42tokyo.jp>       +#+  +:+       +#+        */
+/*   By: ryabuki <ryabuki@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/06 14:29:32 by myokono           #+#    #+#             */
-/*   Updated: 2025/04/06 14:30:56 by myokono          ###   ########.fr       */
+/*   Updated: 2025/04/06 16:00:33 by ryabuki          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -70,6 +70,23 @@ t_env	*init_env_list(char **envp)
 	}
 	return (env_list);
 }
+
+void	free_env_list(t_env *env_list)
+{
+	t_env	*current;
+	t_env	*next;
+
+	current = env_list;
+	while (current)
+	{
+		next = current->next;
+		free(current->key);
+		free(current->value);
+		free(current);
+		current = next;
+	}
+}
+
 char	**env_list_to_array(t_env *env_list)
 {
 	t_env	*current;


### PR DESCRIPTION
This pull request includes several updates and additions to the `minishell` project. The primary changes involve author information updates, the addition of a testing script, and enhancements to memory management functions.

### Author Information Updates:
* Updated author information in `Makefile`, `includes/minishell.h`, `srcs/main.c`, and `srcs/utils/env_init.c` to reflect the new author (`ryabuki`) and updated timestamps. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L6-R9) [[2]](diffhunk://#diff-29c141a418b83334b1dd8ff9066c9fb218e84e274d4381095f6aecb05b8fc5daL9-R9) [[3]](diffhunk://#diff-4df2027984e76b7fa6b2f2bcbdd95ba572cf926771e7c5cd68b3d7747ab782c5L6-R9) [[4]](diffhunk://#diff-6a0f0a2a876446228c6d4bfbc573a9981e90e821c08cd664aceeb8b83c5f2e43L6-R9)

### Testing Enhancements:
* Added a new `test` target in the `Makefile` to run tests using the `mytester.sh` script.
* Added the `mytester.sh` script to automate testing of various shell commands and features, including built-ins, pipes, redirections, quotes, variables, and syntax errors.

### Memory Management Enhancements:
* Added a new function `free_env_list` to `includes/minishell.h` and implemented it in `srcs/utils/env_init.c` to properly free the environment list. [[1]](diffhunk://#diff-29c141a418b83334b1dd8ff9066c9fb218e84e274d4381095f6aecb05b8fc5daR165) [[2]](diffhunk://#diff-6a0f0a2a876446228c6d4bfbc573a9981e90e821c08cd664aceeb8b83c5f2e43R73-R89)