### PR TITLE
exit.c 簡易的なリファクタリングを行いました

### DIFF
--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,7 +6,7 @@
 /*   By: ryabuki <ryabuki@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/01 00:00:00 by user              #+#    #+#             */
-/*   Updated: 2025/04/06 16:02:15 by ryabuki          ###   ########.fr       */
+/*   Updated: 2025/04/06 16:41:28 by ryabuki          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,6 +24,7 @@
 # include <dirent.h>
 # include <string.h>
 # include <errno.h>
+# include <stdbool.h>
 # include <signal.h>
 # include <readline/readline.h>
 # include <readline/history.h>

--- a/srcs/builtins/exit.c
+++ b/srcs/builtins/exit.c
@@ -3,31 +3,31 @@
 /*                                                        :::      ::::::::   */
 /*   exit.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: myokono <myokono@student.42tokyo.jp>       +#+  +:+       +#+        */
+/*   By: ryabuki <ryabuki@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/05 11:20:33 by myokono           #+#    #+#             */
-/*   Updated: 2025/04/05 12:24:39 by myokono          ###   ########.fr       */
+/*   Updated: 2025/04/06 16:44:18 by ryabuki          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "../../includes/minishell.h"
+#include "minishell.h"
 
-static int	is_valid_numeric(char *str)
+static bool	is_valid_numeric(char *str)
 {
 	int	i;
 
 	i = 0;
 	if (str[i] == '+' || str[i] == '-')
 		i++;
-	if (!str[i])
-		return (0);
-	while (str[i])
+	if (str[i] == '\0')
+		return (false);
+	while (str[i] != '\0')
 	{
-		if (!ft_isdigit(str[i]))
-			return (0);
+		if (ft_isdigit(str[i]) == false)
+			return (false);
 		i++;
 	}
-	return (1);
+	return (true);
 }
 
 static void	parse_sign_and_index(const char *str, int *sign, int *i)
@@ -72,8 +72,6 @@ static long long	ft_atoll(const char *str)
 
 int	builtin_exit(t_command *cmd, t_shell *shell)
 {
-	long long	exit_code;
-
 	ft_putstr_fd("exit\n", STDERR_FILENO);
 	if (cmd->args[1] == NULL)
 	{
@@ -88,13 +86,12 @@ int	builtin_exit(t_command *cmd, t_shell *shell)
 		shell->exit_status = 255;
 		return (255);
 	}
-	exit_code = ft_atoll(cmd->args[1]);
 	if (cmd->args[2] != NULL)
 	{
 		error_message("exit: too many arguments");
 		return (1);
 	}
 	shell->running = 0;
-	shell->exit_status = (unsigned char)exit_code;
+	shell->exit_status = (unsigned char)ft_atoll(cmd->args[1]);
 	return (shell->exit_status);
 }


### PR DESCRIPTION
#39 
This pull request includes several changes to the `minishell` project, focusing on header file updates and modifications to the `exit` built-in function. The most important changes include adding a new header file, refactoring the `is_valid_numeric` function, and simplifying the `builtin_exit` function.

Header file updates:

* [`includes/minishell.h`](diffhunk://#diff-29c141a418b83334b1dd8ff9066c9fb218e84e274d4381095f6aecb05b8fc5daR27): Added the `stdbool.h` header to support boolean data types.

Refactoring:

* [`srcs/builtins/exit.c`](diffhunk://#diff-79eb207e8a365fa91728b1497d593142629b1710f659a64670512f2d5c58ea5bL6-R30): Changed the `is_valid_numeric` function to use the `bool` type instead of `int` for better readability and logic clarity.

Simplification:

* [`srcs/builtins/exit.c`](diffhunk://#diff-79eb207e8a365fa91728b1497d593142629b1710f659a64670512f2d5c58ea5bL91-R95): Removed the `exit_code` variable and directly used the `ft_atoll` function call in the `builtin_exit` function to simplify the code.