### PR TITLE
deal with norm at pipe.c

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 Tester
 minishell_tester
 .vscode
+path/

--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@
 #                                                         :::      ::::::::    #
 #    Makefile                                           :+:      :+:    :+:    #
 #                                                     +:+ +:+         +:+      #
-#    By: myokono <myokono@student.42tokyo.jp>       +#+  +:+       +#+         #
+#    By: yabukirento <yabukirento@student.42.fr>    +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2023/01/01 00:00:00 by user              #+#    #+#              #
-#    Updated: 2025/04/07 20:36:31 by myokono          ###   ########.fr        #
+#    Updated: 2025/04/08 13:13:48 by yabukirento      ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -40,6 +40,7 @@ SRCS = $(SRCS_DIR)/main.c \
 	$(EXECUTOR_DIR)/executor_builtin.c \
 	$(EXECUTOR_DIR)/executor_external.c \
 	$(EXECUTOR_DIR)/pipe.c \
+	$(EXECUTOR_DIR)/pipe_exec_cmd.c \
 	$(EXECUTOR_DIR)/pipe_utils.c \
 	$(EXECUTOR_DIR)/redirects.c \
 	$(BUILTINS_DIR)/echo.c \

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,7 +6,7 @@
 /*   By: yabukirento <yabukirento@student.42.fr>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/01 00:00:00 by user              #+#    #+#             */
-/*   Updated: 2025/04/08 11:25:28 by yabukirento      ###   ########.fr       */
+/*   Updated: 2025/04/08 13:11:59 by yabukirento      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -134,6 +134,7 @@ void		cleanup_pipes(t_command *commands);
 void		setup_child_io(t_command *cmd);
 int			setup_redirects(t_command *cmd);
 int			execute_pipeline(t_command *commands, t_shell *shell);
+pid_t	static_execute_commands(t_command *current, t_shell *shell, int stdin_backup);
 
 /* builtins */
 int			builtin_echo(t_command *cmd, t_shell *shell);

--- a/srcs/executor/pipe.c
+++ b/srcs/executor/pipe.c
@@ -6,20 +6,11 @@
 /*   By: yabukirento <yabukirento@student.42.fr>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/27 12:23:15 by myokono           #+#    #+#             */
-/*   Updated: 2025/04/08 12:19:13 by yabukirento      ###   ########.fr       */
+/*   Updated: 2025/04/08 13:12:51 by yabukirento      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../../includes/minishell.h"
-
-static void	fork_and_exec_child(t_command *cmd, t_shell *shell)
-{
-	default_signals();
-	setup_child_io(cmd);
-	if (is_builtin(cmd->args[0]))
-		exit(execute_builtin(cmd, shell));
-	exit(execute_external_forked(cmd, shell));
-}
 
 static int	wait_for_last_pid(pid_t last_pid)
 {
@@ -43,59 +34,19 @@ static int	wait_for_last_pid(pid_t last_pid)
 	return (last_status);
 }
 
-int	execute_pipeline(t_command *commands, t_shell *shell)
+static void	prepare_pipeline(t_command **current, t_command **cmd_list,
+	t_command *commands, int *stdin_backup)
+{
+	*current = commands;
+	*cmd_list = commands;
+	ignore_signals();
+	*stdin_backup = dup(STDIN_FILENO);
+}
+
+static void	close_command_fds(t_command *cmd_list)
 {
 	t_command	*current;
-	pid_t		pid;
-	pid_t		last_pid;
-	t_command	*cmd_list;
-	int			stdin_backup;
 
-	current = commands;
-	cmd_list = commands;
-	ignore_signals();
-	stdin_backup = dup(STDIN_FILENO); // 標準入力のバックアップを取る
-	
-	while (current)
-	{
-		if (!current->args || !current->args[0])
-		{
-			current = current->next;
-			continue ;
-		}
-		
-		// 最後のコマンドが標準入力を読む場合（catなど）は特別な処理
-		if (current->next == NULL || !current->next->args || !current->next->args[0])
-		{
-			if (ft_strcmp(current->args[0], "cat") == 0 && current->args[1] == NULL && 
-				current->input_fd == STDIN_FILENO)
-			{
-				// ヌルデバイスから入力を読むようにする
-				int null_fd = open("/dev/null", O_RDONLY);
-				if (null_fd != -1)
-				{
-					current->input_fd = null_fd;
-				}
-			}
-		}
-		
-		pid = fork();
-		if (pid == -1)
-		{
-			dup2(stdin_backup, STDIN_FILENO); // 元の標準入力に戻す
-			close(stdin_backup);
-			return (system_error("fork"), ERROR);
-		}
-		if (pid == 0)
-		{
-			close(stdin_backup); // 子プロセスでは不要
-			fork_and_exec_child(current, shell);
-		}
-		last_pid = pid;
-		current = current->next;
-	}
-
-	// すべての子プロセスを作成した後にFDをクローズ
 	current = cmd_list;
 	while (current)
 	{
@@ -105,10 +56,26 @@ int	execute_pipeline(t_command *commands, t_shell *shell)
 			close(current->output_fd);
 		current = current->next;
 	}
+}
 
-	// 元の標準入力に戻す
+static void	restore_stdin(int stdin_backup)
+{
 	dup2(stdin_backup, STDIN_FILENO);
 	close(stdin_backup);
-	
+}
+
+int	execute_pipeline(t_command *commands, t_shell *shell)
+{
+	t_command	*current;
+	t_command	*cmd_list;
+	int			stdin_backup;
+	pid_t		last_pid;
+
+	prepare_pipeline(&current, &cmd_list, commands, &stdin_backup);
+	last_pid = static_execute_commands(current, shell, stdin_backup);
+	if (last_pid == ERROR)
+		return (ERROR);
+	close_command_fds(cmd_list);
+	restore_stdin(stdin_backup);
 	return (wait_for_last_pid(last_pid));
 }

--- a/srcs/executor/pipe_exec_cmd.c
+++ b/srcs/executor/pipe_exec_cmd.c
@@ -1,0 +1,87 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   pipe_ut.c                                          :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: yabukirento <yabukirento@student.42.fr>    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/04/08 13:09:57 by yabukirento       #+#    #+#             */
+/*   Updated: 2025/04/08 13:11:25 by yabukirento      ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "minishell.h"
+
+static int	should_skip_command(t_command *current)
+{
+	if (!current->args || !current->args[0])
+		return (1);
+	return (0);
+}
+
+static void	fork_and_exec_child(t_command *cmd, t_shell *shell)
+{
+	default_signals();
+	setup_child_io(cmd);
+	if (is_builtin(cmd->args[0]))
+		exit(execute_builtin(cmd, shell));
+	exit(execute_external_forked(cmd, shell));
+}
+
+static void	handle_special_cat(t_command *current)
+{
+	int	null_fd;
+
+	if (current->next == NULL || !current->next->args || !current->next->args[0])
+	{
+		if (ft_strcmp(current->args[0], "cat") == 0 && current->args[1] == NULL && 
+			current->input_fd == STDIN_FILENO)
+		{
+			null_fd = open("/dev/null", O_RDONLY);
+			if (null_fd != -1)
+				current->input_fd = null_fd;
+		}
+	}
+}
+
+static pid_t	create_process(t_command *current, t_shell *shell, int stdin_backup)
+{
+	pid_t	pid;
+
+	pid = fork();
+	if (pid == -1)
+	{
+		dup2(stdin_backup, STDIN_FILENO);
+		close(stdin_backup);
+		return (system_error("fork"), ERROR);
+	}
+	if (pid == 0)
+	{
+		close(stdin_backup);
+		fork_and_exec_child(current, shell);
+	}
+	return (pid);
+}
+
+pid_t	static_execute_commands(t_command *current, t_shell *shell, int stdin_backup)
+{
+	pid_t	pid;
+	pid_t	last_pid;
+
+	last_pid = 0;
+	while (current)
+	{
+		if (should_skip_command(current))
+		{
+			current = current->next;
+			continue;
+		}
+		handle_special_cat(current);
+		pid = create_process(current, shell, stdin_backup);
+		if (pid == ERROR)
+			return (ERROR);
+		last_pid = pid;
+		current = current->next;
+	}
+	return (last_pid);
+}


### PR DESCRIPTION
This pull request includes several changes to the `Makefile`, `includes/minishell.h`, and the `srcs/executor` directory to refactor the code and improve the execution pipeline. The most important changes include updating author information, adding a new source file, and refactoring the pipeline execution logic.

### Makefile Changes:
* Updated author information in the `Makefile` to reflect the new maintainer.
* Added `pipe_exec_cmd.c` to the list of source files in the `Makefile`.

### Header File Changes:
* Added a new function declaration `pid_t static_execute_commands(t_command *current, t_shell *shell, int stdin_backup);` in `includes/minishell.h`.

### Source Code Refactoring:
* Moved the `fork_and_exec_child` function from `pipe.c` to the new `pipe_exec_cmd.c` file and refactored the pipeline execution logic to improve readability and maintainability. [[1]](diffhunk://#diff-3e38d452289736e99002c28d193ac5b7092f761d9d7c679ba0d81681f154883dL9-L23) [[2]](diffhunk://#diff-3e38d452289736e99002c28d193ac5b7092f761d9d7c679ba0d81681f154883dL46-L98) [[3]](diffhunk://#diff-3e38d452289736e99002c28d193ac5b7092f761d9d7c679ba0d81681f154883dR59-R79) [[4]](diffhunk://#diff-7e780005ec7ccc10d7d50df7903df011c2fbb336ee2a91204c5404eec4398dd7R1-R87)

These changes aim to streamline the execution of commands in the shell, making the codebase more modular and easier to maintain.