### PR TITLE
deal with norm at exit.c pipe_exec_cmd.c redirects.c

### DIFF
--- a/srcs/builtins/exit.c
+++ b/srcs/builtins/exit.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   exit.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: myokono <myokono@student.42.fr>            +#+  +:+       +#+        */
+/*   By: yabukirento <yabukirento@student.42.fr>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/05 11:20:33 by myokono           #+#    #+#             */
-/*   Updated: 2025/04/08 13:25:57 by myokono          ###   ########.fr       */
+/*   Updated: 2025/04/08 14:16:29 by yabukirento      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -34,7 +34,7 @@ static void	parse_sign_and_index(const char *str, int *sign, int *i)
 {
 	*sign = 1;
 	*i = 0;
-	while (str[*i] == ' ' || str[*i] == '\t' || str[*i] == '\n' \
+	while (str[*i] == ' ' || str[*i] == '\t' || str[*i] == '\n'
 		|| str[*i] == '\v' || str[*i] == '\f' || str[*i] == '\r')
 		(*i)++;
 	if (str[*i] == '-')
@@ -80,8 +80,8 @@ int	builtin_exit(t_command *cmd, t_shell *shell)
 	}
 	if (!is_valid_numeric(cmd->args[1]))
 	{
-		command_error("exit", ft_strjoin(cmd->args[1], \
-			": numeric argument required"));
+		command_error("exit", ft_strjoin(cmd->args[1],
+				": numeric argument required"));
 		shell->running = 0;
 		shell->exit_status = 2;
 		return (2);

--- a/srcs/executor/pipe_exec_cmd.c
+++ b/srcs/executor/pipe_exec_cmd.c
@@ -6,7 +6,7 @@
 /*   By: yabukirento <yabukirento@student.42.fr>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/08 13:18:06 by yabukirento       #+#    #+#             */
-/*   Updated: 2025/04/08 13:18:07 by yabukirento      ###   ########.fr       */
+/*   Updated: 2025/04/08 14:21:50 by yabukirento      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -30,12 +30,14 @@ static void	fork_and_exec_child(t_command *cmd, t_shell *shell)
 
 static void	handle_special_cat(t_command *current)
 {
-	int	null_fd;
+	int			null_fd;
+	t_command	*next;
 
-	if (current->next == NULL || !current->next->args || !current->next->args[0])
+	next = current->next;
+	if (next == NULL || !next->args || !next->args[0])
 	{
-		if (ft_strcmp(current->args[0], "cat") == 0 && current->args[1] == NULL && 
-			current->input_fd == STDIN_FILENO)
+		if (ft_strcmp(current->args[0], "cat") == 0
+			&& current->args[1] == NULL && current->input_fd == STDIN_FILENO)
 		{
 			null_fd = open("/dev/null", O_RDONLY);
 			if (null_fd != -1)
@@ -44,26 +46,26 @@ static void	handle_special_cat(t_command *current)
 	}
 }
 
-static pid_t	create_process(t_command *current, t_shell *shell, int stdin_backup)
+static pid_t	new_process(t_command *current, t_shell *shell, int stdin)
 {
 	pid_t	pid;
 
 	pid = fork();
 	if (pid == -1)
 	{
-		dup2(stdin_backup, STDIN_FILENO);
-		close(stdin_backup);
+		dup2(stdin, STDIN_FILENO);
+		close(stdin);
 		return (system_error("fork"), ERROR);
 	}
 	if (pid == 0)
 	{
-		close(stdin_backup);
+		close(stdin);
 		fork_and_exec_child(current, shell);
 	}
 	return (pid);
 }
 
-pid_t	static_execute_commands(t_command *current, t_shell *shell, int stdin_backup)
+pid_t	static_execute_commands(t_command *current, t_shell *shell, int stdin)
 {
 	pid_t	pid;
 	pid_t	last_pid;
@@ -74,10 +76,10 @@ pid_t	static_execute_commands(t_command *current, t_shell *shell, int stdin_back
 		if (should_skip_command(current))
 		{
 			current = current->next;
-			continue;
+			continue ;
 		}
 		handle_special_cat(current);
-		pid = create_process(current, shell, stdin_backup);
+		pid = new_process(current, shell, stdin);
 		if (pid == ERROR)
 			return (ERROR);
 		last_pid = pid;

--- a/srcs/executor/redirects.c
+++ b/srcs/executor/redirects.c
@@ -6,7 +6,7 @@
 /*   By: yabukirento <yabukirento@student.42.fr>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/27 12:54:49 by myokono           #+#    #+#             */
-/*   Updated: 2025/04/08 14:08:36 by yabukirento      ###   ########.fr       */
+/*   Updated: 2025/04/08 14:17:52 by yabukirento      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -28,8 +28,7 @@ static int	setup_redirect_in(t_command *cmd, char *filename)
 	return (SUCCESS);
 }
 
-static int	setup_redirect_out(t_command *cmd, \
-		char *filename, t_token_type type)
+static int	setup_redir_out(t_command *cmd, char *filename, t_token_type type)
 {
 	int	fd;
 	int	flags;
@@ -85,7 +84,7 @@ static int	setup_redir(t_command *cmd, t_token_type type, char *filename)
 	if (type == TOKEN_REDIRECT_IN)
 		return (setup_redirect_in(cmd, filename));
 	else if (type == TOKEN_REDIRECT_OUT || type == TOKEN_APPEND)
-		return (setup_redirect_out(cmd, filename, type));
+		return (setup_redir_out(cmd, filename, type));
 	else if (type == TOKEN_HEREDOC)
 		return (setup_redirect_heredoc(cmd, filename));
 	return (ERROR);


### PR DESCRIPTION
This pull request includes various updates and refactoring changes across multiple files to improve code readability and maintainability. The most important changes include renaming functions for clarity, updating author information in file headers, and refactoring code to enhance readability in specific functions.

### Codebase Improvements:

* Renamed `setup_redirect_out` to `setup_redir_out` for better clarity in `srcs/executor/redirects.c`. [[1]](diffhunk://#diff-7bddf10d032785c782ab6ff7132299a3e88cd020a856979818aa65d3e123f3d4L31-R31) [[2]](diffhunk://#diff-7bddf10d032785c782ab6ff7132299a3e88cd020a856979818aa65d3e123f3d4L88-R87)
* Renamed `create_process` to `new_process` to better reflect its purpose in `srcs/executor/pipe_exec_cmd.c`. [[1]](diffhunk://#diff-7e780005ec7ccc10d7d50df7903df011c2fbb336ee2a91204c5404eec4398dd7L47-R68) [[2]](diffhunk://#diff-7e780005ec7ccc10d7d50df7903df011c2fbb336ee2a91204c5404eec4398dd7L80-R82)

### Code Readability Enhancements:

* Refactored `handle_special_cat` function to use a `next` variable for improved readability in `srcs/executor/pipe_exec_cmd.c`. [[1]](diffhunk://#diff-7e780005ec7ccc10d7d50df7903df011c2fbb336ee2a91204c5404eec4398dd7R34-R40) [[2]](diffhunk://#diff-7e780005ec7ccc10d7d50df7903df011c2fbb336ee2a91204c5404eec4398dd7L47-R68)
* Removed unnecessary line continuation character in `parse_sign_and_index` function in `srcs/builtins/exit.c`.
* Removed unnecessary line continuation character in `builtin_exit` function in `srcs/builtins/exit.c`.

### Author Information Updates:

* Updated author information in file headers for `srcs/builtins/exit.c`, `srcs/executor/pipe_exec_cmd.c`, and `srcs/executor/redirects.c`. [[1]](diffhunk://#diff-79eb207e8a365fa91728b1497d593142629b1710f659a64670512f2d5c58ea5bL6-R9) [[2]](diffhunk://#diff-7e780005ec7ccc10d7d50df7903df011c2fbb336ee2a91204c5404eec4398dd7L9-R9) [[3]](diffhunk://#diff-7bddf10d032785c782ab6ff7132299a3e88cd020a856979818aa65d3e123f3d4L9-R9)