### PR TITLE
deal with norm at parser.c

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: yabukirento <yabukirento@student.42.fr>    +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2023/01/01 00:00:00 by user              #+#    #+#              #
-#    Updated: 2025/04/08 13:26:34 by yabukirento      ###   ########.fr        #
+#    Updated: 2025/04/08 14:31:36 by yabukirento      ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -20,6 +20,8 @@ LIBS = -L./libft -lft -lreadline
 # ソースファイルディレクトリ
 SRCS_DIR = srcs
 PARSER_DIR = $(SRCS_DIR)/parser
+PARSER_COMMAND_DIR = $(PARSER_DIR)/command
+PARSER_REDIRECT_DIR = $(PARSER_DIR)/redirect
 EXECUTOR_DIR = $(SRCS_DIR)/executor
 BUILTINS_DIR = $(SRCS_DIR)/builtins
 UTILS_DIR = $(SRCS_DIR)/utils
@@ -35,6 +37,8 @@ SRCS = $(SRCS_DIR)/main.c \
 	$(PARSER_DIR)/double_quote.c \
 	$(PARSER_DIR)/env.c \
 	$(PARSER_DIR)/command.c \
+	$(PARSER_COMMAND_DIR)/command_utils.c \
+	$(PARSER_REDIRECT_DIR)/redirect_utils.c \
 	$(EXECUTOR_DIR)/executor.c \
 	$(EXECUTOR_DIR)/path.c \
 	$(EXECUTOR_DIR)/executor_builtin.c \

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,7 +6,7 @@
 /*   By: yabukirento <yabukirento@student.42.fr>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/01 00:00:00 by user              #+#    #+#             */
-/*   Updated: 2025/04/08 14:10:47 by yabukirento      ###   ########.fr       */
+/*   Updated: 2025/04/08 14:31:36 by yabukirento      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -116,6 +116,15 @@ int			parse(t_shell *shell);
 void		free_commands(t_command *commands);
 t_command	*create_command(void);
 void		add_command(t_command **commands, t_command *new_command);
+
+/* parser/command */
+int			add_arg(t_command *cmd, char *arg);
+int			handle_pipe(t_token **tokens, t_command *cmd, t_command **commands);
+
+/* parser/redirect */
+t_token		*process_redirect_tokens(t_token **tokens, t_token_type type);
+void		add_redirect_to_command(t_command *cmd, t_token *redirect_token);
+int			handle_redirect(t_token **tokens, t_command *cmd);
 
 /* env */
 char		*expand_variables(char *str, t_shell *shell);

--- a/srcs/parser/command/command_utils.c
+++ b/srcs/parser/command/command_utils.c
@@ -1,0 +1,54 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   command_utils.c                                    :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: yabukirento <yabukirento@student.42.fr>    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/04/08 14:30:00 by yabukirento       #+#    #+#             */
+/*   Updated: 2025/04/08 14:31:36 by yabukirento      ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "../../../includes/minishell.h"
+
+int	add_arg(t_command *cmd, char *arg)
+{
+	char	**new_args;
+	int		i;
+	int		size;
+
+	size = 0;
+	if (cmd->args)
+	{
+		while (cmd->args[size])
+			size++;
+	}
+	new_args = malloc(sizeof(char *) * (size + 2));
+	if (!new_args)
+		return (error_message("Memory allocation error"), ERROR);
+	i = 0;
+	while (i < size)
+	{
+		new_args[i] = cmd->args[i];
+		i++;
+	}
+	new_args[size] = ft_strdup(arg);
+	new_args[size + 1] = NULL;
+	if (cmd->args)
+		free(cmd->args);
+	cmd->args = new_args;
+	return (SUCCESS);
+}
+
+int	handle_pipe(t_token **tokens, t_command *cmd, t_command **commands)
+{
+	if (!cmd->args)
+	{
+		error_message("Syntax error near unexpected token `|'");
+		return (ERROR);
+	}
+	add_command(commands, cmd);
+	*tokens = (*tokens)->next;
+	return (SUCCESS);
+} 

--- a/srcs/parser/parser.c
+++ b/srcs/parser/parser.c
@@ -3,150 +3,73 @@
 /*                                                        :::      ::::::::   */
 /*   parser.c                                           :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: myokono <myokono@student.42tokyo.jp>       +#+  +:+       +#+        */
+/*   By: yabukirento <yabukirento@student.42.fr>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/01 00:00:00 by user              #+#    #+#             */
-/*   Updated: 2025/04/08 11:33:00 by myokono          ###   ########.fr       */
+/*   Updated: 2025/04/08 14:33:53 by yabukirento      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../../includes/minishell.h"
 
-static int	add_arg(t_command *cmd, char *arg)
+static int	process_token(t_token **current_token, t_command **current_cmd,
+	t_command **commands)
 {
-	char	**new_args;
-	int		i;
-	int		size;
-
-	size = 0;
-	if (cmd->args)
+	if ((*current_token)->type == TOKEN_WORD)
 	{
-		while (cmd->args[size])
-			size++;
+		add_arg(*current_cmd, (*current_token)->value);
+		*current_token = (*current_token)->next;
 	}
-	new_args = malloc(sizeof(char *) * (size + 2));
-	if (!new_args)
-		return (error_message("Memory allocation error"), ERROR);
-	i = 0;
-	while (i < size)
+	else if ((*current_token)->type == TOKEN_REDIRECT_IN
+		|| (*current_token)->type == TOKEN_REDIRECT_OUT
+		|| (*current_token)->type == TOKEN_HEREDOC
+		|| (*current_token)->type == TOKEN_APPEND)
 	{
-		new_args[i] = cmd->args[i];
-		i++;
+		if (handle_redirect(current_token, *current_cmd) == ERROR)
+			return (ERROR);
 	}
-	new_args[size] = ft_strdup(arg);
-	new_args[size + 1] = NULL;
-	if (cmd->args)
-		free(cmd->args);
-	cmd->args = new_args;
-	return (SUCCESS);
-}
-
-static int	handle_redirect(t_token **tokens, t_command *cmd)
-{
-	t_token_type	type;
-	char			*filename;
-	t_token			*redirect_token;
-	t_token			*filename_token;
-
-	type = (*tokens)->type;
-	redirect_token = create_token(type, ft_strdup((*tokens)->value));
-	*tokens = (*tokens)->next;
-	if (!*tokens || (*tokens)->type != TOKEN_WORD)
+	else if ((*current_token)->type == TOKEN_PIPE)
 	{
-		free_tokens(redirect_token);
-		error_message("Syntax error near unexpected token");
-		return (ERROR);
-	}
-	filename = (*tokens)->value;
-	filename_token = create_token(TOKEN_WORD, ft_strdup(filename));
-	*tokens = (*tokens)->next;
-
-	redirect_token->next = filename_token;
-
-	if (!cmd->redirects)
-	{
-		cmd->redirects = redirect_token;
+		if (handle_pipe(current_token, *current_cmd, commands) == ERROR)
+			return (ERROR);
+		*current_cmd = create_command();
 	}
 	else
-	{
-		t_token *current = cmd->redirects;
-		while (current->next)
-			current = current->next;
-		current->next = redirect_token;
-	}
-
+		return (ERROR);
 	return (SUCCESS);
 }
 
-static int	handle_pipe(t_token **tokens, t_command *cmd, t_command **commands)
+static int	finalize_parse(t_command *current_cmd, t_command **commands)
 {
-	if (!cmd->args)
-	{
-		error_message("Syntax error near unexpected token `|'");
-		return (ERROR);
-	}
-	add_command(commands, cmd);
-	*tokens = (*tokens)->next;
+	if (current_cmd->args || current_cmd->input_fd != STDIN_FILENO
+		|| current_cmd->output_fd != STDOUT_FILENO)
+		add_command(commands, current_cmd);
+	else
+		free_commands(current_cmd);
 	return (SUCCESS);
 }
 
 int	parse(t_shell *shell)
 {
-	t_token		*current_token;
-	t_command	*current_cmd;
+	t_token		*cur_token;
+	t_command	*cur_cmd;
 
 	if (!shell->tokens)
 		return (SUCCESS);
 	shell->commands = NULL;
-	current_token = shell->tokens;
-	current_cmd = create_command();
-	if (!current_cmd)
+	cur_token = shell->tokens;
+	cur_cmd = create_command();
+	if (!cur_cmd)
+		return (error_message("Memory allocation error"), ERROR);
+	while (cur_token)
 	{
-		error_message("Memory allocation error");
-		return (ERROR);
-	}
-	while (current_token)
-	{
-		if (current_token->type == TOKEN_WORD)
+		if (process_token(&cur_token, &cur_cmd, &shell->commands) == ERROR)
 		{
-			add_arg(current_cmd, current_token->value);
-			current_token = current_token->next;
-		}
-		else if (current_token->type == TOKEN_REDIRECT_IN
-			|| current_token->type == TOKEN_REDIRECT_OUT
-			|| current_token->type == TOKEN_HEREDOC
-			|| current_token->type == TOKEN_APPEND)
-		{
-			if (handle_redirect(&current_token, current_cmd) == ERROR)
-			{
-				free_commands(current_cmd);
-				return (ERROR);
-			}
-		}
-		else if (current_token->type == TOKEN_PIPE)
-		{
-			if (handle_pipe(&current_token, current_cmd, &shell->commands) == ERROR)
-			{
-				free_commands(current_cmd);
-				free_commands(shell->commands);
-				shell->commands = NULL;
-				return (ERROR);
-			}
-			current_cmd = create_command();
-		}
-		else
-		{
-			error_message("Parser error: unknown token type");
-			free_commands(current_cmd);
+			free_commands(cur_cmd);
 			free_commands(shell->commands);
 			shell->commands = NULL;
 			return (ERROR);
 		}
 	}
-	if (current_cmd->args || current_cmd->input_fd != STDIN_FILENO
-		|| current_cmd->output_fd != STDOUT_FILENO)
-		add_command(&shell->commands, current_cmd);
-	else
-		free_commands(current_cmd);
-	return (SUCCESS);
+	return (finalize_parse(cur_cmd, &shell->commands));
 }

--- a/srcs/parser/redirect/redirect_utils.c
+++ b/srcs/parser/redirect/redirect_utils.c
@@ -1,0 +1,64 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   redirect_utils.c                                   :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: yabukirento <yabukirento@student.42.fr>    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/04/08 14:30:00 by yabukirento       #+#    #+#             */
+/*   Updated: 2025/04/08 14:31:36 by yabukirento      ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "../../../includes/minishell.h"
+
+t_token	*process_redirect_tokens(t_token **tokens, t_token_type type)
+{
+	t_token	*redirect_token;
+	t_token	*filename_token;
+
+	redirect_token = create_token(type, ft_strdup((*tokens)->value));
+	*tokens = (*tokens)->next;
+	if (!*tokens || (*tokens)->type != TOKEN_WORD)
+	{
+		free_tokens(redirect_token);
+		error_message("Syntax error near unexpected token");
+		return (NULL);
+	}
+	filename_token = create_token(TOKEN_WORD, ft_strdup((*tokens)->value));
+	*tokens = (*tokens)->next;
+
+	redirect_token->next = filename_token;
+	return (redirect_token);
+}
+
+void	add_redirect_to_command(t_command *cmd, t_token *redirect_token)
+{
+	t_token	*current;
+
+	if (!cmd->redirects)
+	{
+		cmd->redirects = redirect_token;
+	}
+	else
+	{
+		current = cmd->redirects;
+		while (current->next)
+			current = current->next;
+		current->next = redirect_token;
+	}
+}
+
+int	handle_redirect(t_token **tokens, t_command *cmd)
+{
+	t_token_type	type;
+	t_token			*redirect_token;
+
+	type = (*tokens)->type;
+	redirect_token = process_redirect_tokens(tokens, type);
+	if (!redirect_token)
+		return (ERROR);
+	
+	add_redirect_to_command(cmd, redirect_token);
+	return (SUCCESS);
+} 


### PR DESCRIPTION
This pull request includes several changes to the `Makefile`, `minishell.h`, and various source files to improve the structure and functionality of the parser and command handling in the project. The most important changes include the addition of new directories for parser commands and redirects, the creation of utility functions for command and redirect handling, and the refactoring of the parser to enhance readability and maintainability.

### Structural Improvements:
* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R23-R24): Added `PARSER_COMMAND_DIR` and `PARSER_REDIRECT_DIR` directories to organize parser-related files. Updated the `SRCS` variable to include new utility files for command and redirect handling. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R23-R24) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R40-R41)

### New Utility Functions:
* [`includes/minishell.h`](diffhunk://#diff-29c141a418b83334b1dd8ff9066c9fb218e84e274d4381095f6aecb05b8fc5daR120-R128): Added declarations for new utility functions related to command and redirect handling.
* [`srcs/parser/command/command_utils.c`](diffhunk://#diff-4a673d9b762ed1fe224ed679ba94a448eb9769687f0d9d2941aa9924fdacb4aaR1-R54): Created new utility functions `add_arg` and `handle_pipe` to manage command arguments and pipe tokens.
* [`srcs/parser/redirect/redirect_utils.c`](diffhunk://#diff-0848f02681db7542a04502a6fac58e08de4a6df0a8121dfd1adffc2da926e990R1-R64): Created new utility functions `process_redirect_tokens`, `add_redirect_to_command`, and `handle_redirect` to manage redirect tokens.

### Parser Refactoring:
* [`srcs/parser/parser.c`](diffhunk://#diff-9f60c271c563339e133e729496a6abbe5622d6e17a0088c5fd5bd3862b72783cL6-R74): Refactored the parser to use new utility functions, improving the readability and maintainability of the code. The `parse` function now utilizes `process_token` and `finalize_parse` to handle different token types and finalize command parsing.

### Minor Updates:
* Updated file headers in `Makefile` and `includes/minishell.h` to reflect the latest modification timestamps. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L9-R9) [[2]](diffhunk://#diff-29c141a418b83334b1dd8ff9066c9fb218e84e274d4381095f6aecb05b8fc5daL9-R9)