### PR TITLE
Feature/exit

### DIFF
--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,7 +6,7 @@
 /*   By: myokono <myokono@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/01 00:00:00 by user              #+#    #+#             */
-/*   Updated: 2025/04/08 14:40:22 by myokono          ###   ########.fr       */
+/*   Updated: 2025/04/09 17:08:44 by myokono          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -61,6 +61,7 @@ typedef struct s_command
 	char				**args;
 	int					input_fd;
 	int					output_fd;
+	bool				is_in_pipe;
 	t_token				*redirects;
 	struct s_command	*next;
 }	t_command;

--- a/srcs/builtins/exit.c
+++ b/srcs/builtins/exit.c
@@ -6,7 +6,7 @@
 /*   By: myokono <myokono@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/05 11:20:33 by myokono           #+#    #+#             */
-/*   Updated: 2025/04/09 17:02:12 by myokono          ###   ########.fr       */
+/*   Updated: 2025/04/09 17:12:21 by myokono          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -83,7 +83,8 @@ int	builtin_exit(t_command *cmd, t_shell *shell)
 {
 	long long	exit;
 
-	ft_putstr_fd("exit\n", STDERR_FILENO);
+	if (cmd->is_in_pipe == false)
+		ft_putstr_fd("exit\n", STDERR_FILENO);
 	if (cmd->args[1] == NULL)
 	{
 		shell->running = 0;

--- a/srcs/parser/command.c
+++ b/srcs/parser/command.c
@@ -6,7 +6,7 @@
 /*   By: myokono <myokono@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/06 21:29:11 by myokono           #+#    #+#             */
-/*   Updated: 2025/04/06 21:30:14 by myokono          ###   ########.fr       */
+/*   Updated: 2025/04/09 17:11:17 by myokono          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,6 +24,7 @@ t_command	*create_command(void)
 	cmd->output_fd = STDOUT_FILENO;
 	cmd->redirects = NULL;
 	cmd->next = NULL;
+	cmd->is_in_pipe = false;
 	return (cmd);
 }
 


### PR DESCRIPTION
This pull request includes several changes to improve the handling of the `exit` builtin command and to add a new attribute to the `t_command` structure. The most important changes include adding a `is_in_pipe` attribute to the `t_command` structure, refactoring the `exit` command to handle numeric errors more cleanly, and updating the function that creates a new command to initialize the new attribute.

Enhancements to `t_command` structure:

* [`includes/minishell.h`](diffhunk://#diff-29c141a418b83334b1dd8ff9066c9fb218e84e274d4381095f6aecb05b8fc5daR64): Added a new `bool is_in_pipe` attribute to the `t_command` structure to track whether a command is part of a pipeline.

Improvements to `exit` command:

* [`srcs/builtins/exit.c`](diffhunk://#diff-79eb207e8a365fa91728b1497d593142629b1710f659a64670512f2d5c58ea5bR73-R101): Refactored the `builtin_exit` function to handle numeric errors using a new `numeric_error` function, and added checks for numeric argument limits.
* [`srcs/parser/command.c`](diffhunk://#diff-299790f82f1dacb65eef26a92bb82bc49fa8de751ce47ba4bd93f949dc5d892dR27): Updated the `create_command` function to initialize the new `is_in_pipe` attribute to `false`.

Code ownership updates:

* [`includes/minishell.h`](diffhunk://#diff-29c141a418b83334b1dd8ff9066c9fb218e84e274d4381095f6aecb05b8fc5daL9-R9): Updated the file header to reflect the new modification date and author.
* [`srcs/builtins/exit.c`](diffhunk://#diff-79eb207e8a365fa91728b1497d593142629b1710f659a64670512f2d5c58ea5bL6-R9): Updated the file header to reflect the new modification date and author.
* [`srcs/parser/command.c`](diffhunk://#diff-299790f82f1dacb65eef26a92bb82bc49fa8de751ce47ba4bd93f949dc5d892dL9-R9): Updated the file header to reflect the new modification date and author.