### PR TITLE
makeできるようにしました

### DIFF
--- a/srcs/executor/setup_redirects.c
+++ b/srcs/executor/setup_redirects.c
@@ -6,7 +6,7 @@
 /*   By: ryabuki <ryabuki@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/12 16:55:54 by ryabuki           #+#    #+#             */
-/*   Updated: 2025/04/12 17:36:08 by ryabuki          ###   ########.fr       */
+/*   Updated: 2025/04/12 17:51:45 by ryabuki          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,7 +19,7 @@ static bool	loop(int pipe_fd[2], char *delimiter, char **saved)
 	while (true)
 	{
 		write(STDOUT_FILENO, "> ", 2);
-		line = get_next_line(STDIN_FILENO, &saved);
+		line = get_next_line(STDIN_FILENO, saved);
 		if (g_signal_status == -1)
 		{
 			free(line);
@@ -44,7 +44,6 @@ static bool	loop(int pipe_fd[2], char *delimiter, char **saved)
 int	setup_redirect_heredoc(t_command *cmd, char *delimiter)
 {
 	int		pipe_fd[2];
-	char	*line;
 	char	*saved;
 
 	saved = ft_strdup("");


### PR DESCRIPTION
This pull request includes changes to the `srcs/executor/setup_redirects.c` file to fix a bug and improve code readability. The most important changes include updating the `get_next_line` function call and removing an unused variable.

Bug fix:

* [`srcs/executor/setup_redirects.c`](diffhunk://#diff-0900985717e5fc0f982ef7943fa0a7e0d4168eb7272688ba5fd3fe60b73cb326L22-R22): Modified the `get_next_line` function call in the `loop` function to correctly pass the `saved` parameter without the address operator.

Code readability:

* [`srcs/executor/setup_redirects.c`](diffhunk://#diff-0900985717e5fc0f982ef7943fa0a7e0d4168eb7272688ba5fd3fe60b73cb326L47): Removed the unused `line` variable in the `setup_redirect_heredoc` function.