### PR TITLE
deal with norm

### DIFF
--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,7 +6,7 @@
 /*   By: ryabuki <ryabuki@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/01 00:00:00 by user              #+#    #+#             */
-/*   Updated: 2025/04/12 21:06:01 by ryabuki          ###   ########.fr       */
+/*   Updated: 2025/04/12 21:35:17 by ryabuki          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -181,6 +181,6 @@ int			ft_strcmp(const char *s1, const char *s2);
 bool		join_result(char **result, char *add);
 bool		join_result_free(char **result, char *add);
 
-int setup_redir_return_fd(t_token_type type, char *delimiter);
+int			setup_redir_return_fd(t_token_type type, char *delimiter);
 
 #endif

--- a/srcs/executor/redirects.c
+++ b/srcs/executor/redirects.c
@@ -6,7 +6,7 @@
 /*   By: ryabuki <ryabuki@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/27 12:54:49 by myokono           #+#    #+#             */
-/*   Updated: 2025/04/12 21:06:21 by ryabuki          ###   ########.fr       */
+/*   Updated: 2025/04/12 21:56:22 by ryabuki          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -50,155 +50,40 @@ static int	setup_redir_out(t_command *cmd, char *filename, t_token_type type)
 	return (SUCCESS);
 }
 
-static int	setup_redir(t_command *cmd, t_token_type type, char *filename)
+static int	heredoc(t_command *cmd, t_token *token, int last_fd, int heredoc_fd)
 {
-	if (type == TOKEN_REDIRECT_IN)
-		return (setup_redirect_in(cmd, filename));
-	else if (type == TOKEN_REDIRECT_OUT || type == TOKEN_APPEND)
-		return (setup_redir_out(cmd, filename, type));
-	else if (type == TOKEN_HEREDOC)
-		return (setup_redirect_heredoc(cmd, filename));
-	return (ERROR);
-}
+	t_token	*next;
 
-// int	setup_redirects(t_command *cmd)
-// {
-// 	t_token	*token;
-// 	t_token	*next;
-
-// 	token = cmd->redirects;
-// 	while (token)
-// 	{
-// 		next = token->next;
-// 		if (!next)
-// 		{
-// 			error_message("Missing filename for redirection");
-// 			return (ERROR);
-// 		}
-// 		if (setup_redir(cmd, token->type, next->value) == ERROR)
-// 			return (ERROR);
-// 		token = next->next;
-// 	}
-// 	return (SUCCESS);
-// }
-
-
-
-// int setup_redirects(t_command *cmd)
-// {
-// 	t_token *token;
-// 	t_token *next;
-	
-// 	// ステップ1: 入力リダイレクト（<）を処理
-// 	token = cmd->redirects;
-// 	while (token)
-// 	{
-// 		next = token->next;
-// 		if (!next)
-// 		{
-// 			error_message("Missing filename for redirection");
-// 			return (ERROR);
-// 		}
-// 		if (token->type == TOKEN_REDIRECT_IN)
-// 		{
-// 			if (setup_redir(cmd, token->type, next->value) == ERROR)
-// 				return (ERROR);
-// 		}
-// 		token = next->next;
-// 	}
-	
-// 	// ステップ2: 最後のヒアドキュメント（<<）を処理
-// 	t_token *last_heredoc = NULL;
-// 	t_token *last_heredoc_value = NULL;
-// 	token = cmd->redirects;
-// 	while (token)
-// 	{
-// 		next = token->next;
-// 		if (!next)
-// 			break;
-// 		if (token->type == TOKEN_HEREDOC)
-// 		{
-// 			last_heredoc = token;
-// 			last_heredoc_value = next;
-// 		}
-// 		token = next->next;
-// 	}
-// 	if (last_heredoc && last_heredoc_value)
-// 	{
-// 		if (setup_redir(cmd, last_heredoc->type, last_heredoc_value->value) == ERROR)
-// 			return (ERROR);
-// 	}
-
-// 	// ステップ3: 出力リダイレクト（>、>>）を処理
-// 	token = cmd->redirects;
-// 	while (token)
-// 	{
-// 		next = token->next;
-// 		if (!next)
-// 			break;
-		
-// 		if (token->type == TOKEN_REDIRECT_OUT || token->type == TOKEN_APPEND)
-// 		{
-// 			if (setup_redir(cmd, token->type, next->value) == ERROR)
-// 				return (ERROR);
-// 		}
-		
-// 		token = next->next;
-// 	}
-	
-// 	return (SUCCESS);
-// }
-
-int setup_redirects(t_command *cmd)
-{
-	t_token *token;
-	t_token *next;
-
-	// 1. ヒアドキュメント（<<）を前から処理
-	int last_heredoc_fd = -1;
-
-	token = cmd->redirects;
 	while (token)
 	{
 		next = token->next;
 		if (!next)
-			break;
+			break ;
 		if (token->type == TOKEN_HEREDOC)
 		{
-			int heredoc_fd = setup_redir_return_fd(token->type, next->value);
+			heredoc_fd = setup_redir_return_fd(token->type, next->value);
 			if (heredoc_fd == -1)
 				return (ERROR);
-			if (last_heredoc_fd != -1)
-				close(last_heredoc_fd);  // 前の heredoc fd は閉じる
-			last_heredoc_fd = heredoc_fd;
+			if (last_fd != -1)
+				close(last_fd);
+			last_fd = heredoc_fd;
 		}
 		token = next->next;
 	}
-	
-	// 最後の heredoc の fd を input_fd に設定
-	if (last_heredoc_fd != -1)
+	if (last_fd != -1)
 	{
 		if (cmd->input_fd != STDIN_FILENO)
 			close(cmd->input_fd);
-		cmd->input_fd = last_heredoc_fd;
+		cmd->input_fd = last_fd;
 	}
-	
+	return (SUCCESS);
+}
 
-	// 2. 出力（>、>>）
-	token = cmd->redirects;
-	while (token)
-	{
-		next = token->next;
-		if (!next) break;
-		if (token->type == TOKEN_REDIRECT_OUT || token->type == TOKEN_APPEND)
-		{
-			if (setup_redir(cmd, token->type, next->value) == ERROR)
-				return (ERROR);
-		}
-		token = next->next;
-	}
+static int	redir_in_helper(t_command *cmd)
+{
+	t_token	*token;
+	t_token	*next;
 
-	// 3. 入力（<）※HEREDOC より後に処理されると上書きしてしまうので注意
 	token = cmd->redirects;
 	while (token)
 	{
@@ -210,11 +95,36 @@ int setup_redirects(t_command *cmd)
 		}
 		if (token->type == TOKEN_REDIRECT_IN)
 		{
-			if (setup_redir(cmd, token->type, next->value) == ERROR)
+			if (setup_redirect_in(cmd, token->value) == ERROR)
 				return (ERROR);
 		}
 		token = next->next;
 	}
+	return (SUCCESS);
+}
 
+int	setup_redirects(t_command *cmd)
+{
+	t_token	*token;
+	t_token	*next;
+
+	token = cmd->redirects;
+	if (heredoc(cmd, cmd->redirects, -1, 0) == false)
+		return (ERROR);
+	token = cmd->redirects;
+	while (token)
+	{
+		next = token->next;
+		if (!next)
+			break ;
+		if (token->type == TOKEN_REDIRECT_OUT || token->type == TOKEN_APPEND)
+		{
+			if (setup_redir_out(cmd, token->value, token->type) == ERROR)
+				return (ERROR);
+		}
+		token = next->next;
+	}
+	if (redir_in_helper(cmd) == false)
+		return (ERROR);
 	return (SUCCESS);
 }

--- a/srcs/executor/setup_redirects.c
+++ b/srcs/executor/setup_redirects.c
@@ -6,7 +6,7 @@
 /*   By: ryabuki <ryabuki@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/12 16:55:54 by ryabuki           #+#    #+#             */
-/*   Updated: 2025/04/12 21:06:49 by ryabuki          ###   ########.fr       */
+/*   Updated: 2025/04/12 21:58:47 by ryabuki          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -71,52 +71,27 @@ static bool	loop(int pipe_fd[2], char *delimiter, char **saved)
 	return (true);
 }
 
-int	setup_redirect_heredoc(t_command *cmd, char *delimiter)
+int	setup_redir_return_fd(t_token_type type, char *delimiter)
 {
 	int		pipe_fd[2];
 	char	*saved;
 
-	saved = ft_strdup("");
-	if (saved == NULL)
-		return (ERROR);
-	if (pipe(pipe_fd) == -1)
-	{
-		system_error("pipe");
-		return (ERROR);
-	}
-	setup_signal_heredoc();
-	if (loop(pipe_fd, delimiter, &saved) == ERROR)
-		return (ERROR);
-	close(pipe_fd[1]);
-	if (cmd->input_fd != STDIN_FILENO)
-		close(cmd->input_fd);
-	cmd->input_fd = pipe_fd[0];
-	free(saved);
-	return (SUCCESS);
-}
-
-int setup_redir_return_fd(t_token_type type, char *delimiter)
-{
 	if (type != TOKEN_HEREDOC)
-		return (-1); // 対象外
-
-	int pipe_fd[2];
-	char *saved = ft_strdup("");
+		return (-1);
+	saved = ft_strdup("");
 	if (!saved)
 		return (-1);
 	if (pipe(pipe_fd) == -1)
 		return (-1);
-
 	setup_signal_heredoc();
-	if (!loop(pipe_fd, delimiter, &saved))
+	if (loop(pipe_fd, delimiter, &saved) == ERROR)
 	{
 		free(saved);
 		close(pipe_fd[0]);
 		close(pipe_fd[1]);
 		return (-1);
 	}
-
-	close(pipe_fd[1]); // 書き込み側閉じる
+	close(pipe_fd[1]);
 	free(saved);
-	return pipe_fd[0]; // 読み取り側だけ返す
+	return (pipe_fd[0]);
 }

--- a/srcs/utils/env_init.c
+++ b/srcs/utils/env_init.c
@@ -6,7 +6,7 @@
 /*   By: ryabuki <ryabuki@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/06 14:29:32 by myokono           #+#    #+#             */
-/*   Updated: 2025/04/12 17:38:57 by ryabuki          ###   ########.fr       */
+/*   Updated: 2025/04/12 21:42:43 by ryabuki          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -71,22 +71,30 @@ t_env	*init_env_list(char **envp)
 	return (env_list);
 }
 
+static int	env_count(t_env *env_list)
+{
+	int		i;
+	t_env	*current;
+
+	current = env_list;
+	i = 0;
+	current = env_list;
+	while (current)
+	{
+		i++;
+		current = current->next;
+	}
+	return (i);
+}
+
 char	**env_list_to_array(t_env *env_list)
 {
 	t_env	*current;
 	char	**env_array;
-	int		count;
 	int		i;
 	char	*tmp;
 
-	count = 0;
-	current = env_list;
-	while (current)
-	{
-		count++;
-		current = current->next;
-	}
-	env_array = malloc(sizeof(char *) * (count + 1));
+	env_array = malloc(sizeof(char *) * (env_count(env_list) + 1));
 	if (!env_array)
 		return (NULL);
 	i = 0;
@@ -94,8 +102,12 @@ char	**env_list_to_array(t_env *env_list)
 	while (current)
 	{
 		tmp = ft_strjoin(current->key, "=");
+		if (tmp == NULL)
+			return (NULL);
 		env_array[i] = ft_strjoin(tmp, current->value);
 		free(tmp);
+		if (env_array[i])
+			return (NULL);
 		current = current->next;
 		i++;
 	}


### PR DESCRIPTION
This pull request includes several important changes to the `executor` and `utils` components of the codebase. The modifications focus on refactoring the redirection setup functions and improving the environment list handling. Below is a summary of the most significant changes:

### Refactoring redirection setup functions:

* [`srcs/executor/redirects.c`](diffhunk://#diff-7bddf10d032785c782ab6ff7132299a3e88cd020a856979818aa65d3e123f3d4L53-R128): Refactored the `setup_redirects` function to improve readability and maintainability by breaking it down into smaller helper functions and removing commented-out code.
* [`srcs/executor/setup_redirects.c`](diffhunk://#diff-0900985717e5fc0f982ef7943fa0a7e0d4168eb7272688ba5fd3fe60b73cb326L74-R96): Renamed and refactored the `setup_redirect_heredoc` function to `setup_redir_return_fd` to better describe its purpose and improve code clarity.

### Environment list handling improvements:

* [`srcs/utils/env_init.c`](diffhunk://#diff-6a0f0a2a876446228c6d4bfbc573a9981e90e821c08cd664aceeb8b83c5f2e43L74-R110): Introduced a new helper function `env_count` to count the number of environment variables, improving the readability and maintainability of the `env_list_to_array` function.

### File header updates:

* [`includes/minishell.h`](diffhunk://#diff-29c141a418b83334b1dd8ff9066c9fb218e84e274d4381095f6aecb05b8fc5daL9-R9): Updated the file header timestamp to reflect recent changes.
* [`srcs/executor/redirects.c`](diffhunk://#diff-7bddf10d032785c782ab6ff7132299a3e88cd020a856979818aa65d3e123f3d4L9-R9): Updated the file header timestamp to reflect recent changes.
* [`srcs/executor/setup_redirects.c`](diffhunk://#diff-0900985717e5fc0f982ef7943fa0a7e0d4168eb7272688ba5fd3fe60b73cb326L9-R9): Updated the file header timestamp to reflect recent changes.
* [`srcs/utils/env_init.c`](diffhunk://#diff-6a0f0a2a876446228c6d4bfbc573a9981e90e821c08cd664aceeb8b83c5f2e43L9-R9): Updated the file header timestamp to reflect recent changes.