### PR TITLE
leak対応

### DIFF
--- a/srcs/gnl/srcs/get_next_line.c
+++ b/srcs/gnl/srcs/get_next_line.c
@@ -6,7 +6,7 @@
 /*   By: ryabuki <ryabuki@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/19 19:05:04 by yabukirento       #+#    #+#             */
-/*   Updated: 2025/04/12 17:35:39 by ryabuki          ###   ########.fr       */
+/*   Updated: 2025/04/13 18:44:31 by ryabuki          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -65,6 +65,8 @@ static char	*ft_shift_pointer(size_t len, char *saved)
 	char	*tmp;
 
 	tmp = ft_strdup(saved + len + 1);
+	free(saved);
+	saved = NULL;
 	if (tmp == NULL)
 		return (NULL);
 	return (tmp);


### PR DESCRIPTION
This pull request includes updates to the `get_next_line.c` file to improve memory management by adding a `free` call and setting a pointer to `NULL` after shifting it. Additionally, the file header has been updated with a new timestamp.

Memory management improvements:

* [`srcs/gnl/srcs/get_next_line.c`](diffhunk://#diff-c92d37f79491fe0532e0a5e2fda5eb5dde3e5d19eaa77689efab09fca26fd05aR68-R69): Added `free(saved)` and set `saved` to `NULL` in the `ft_shift_pointer` function to prevent memory leaks.

Documentation update:

* [`srcs/gnl/srcs/get_next_line.c`](diffhunk://#diff-c92d37f79491fe0532e0a5e2fda5eb5dde3e5d19eaa77689efab09fca26fd05aL9-R9): Updated the timestamp in the file header comment.