### PR TITLE
Ctrl +C でシェルを終了した場合の返り値を130になるようにシグナルを修正しました

### DIFF
--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   minishell.h                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: myokono <myokono@student.42.fr>            +#+  +:+       +#+        */
+/*   By: yabukirento <yabukirento@student.42.fr>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/01 00:00:00 by user              #+#    #+#             */
-/*   Updated: 2025/04/13 18:09:17 by myokono          ###   ########.fr       */
+/*   Updated: 2025/04/16 10:31:07 by yabukirento      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -34,8 +34,6 @@
 
 # define SUCCESS 0
 # define ERROR 1
-# define EXIT_SUCCESS 0
-# define EXIT_FAILURE 1
 
 extern int		g_signal_status;
 

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   main.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: myokono <myokono@student.42tokyo.jp>       +#+  +:+       +#+        */
+/*   By: yabukirento <yabukirento@student.42.fr>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/27 19:12:06 by myokono           #+#    #+#             */
-/*   Updated: 2025/04/13 20:24:55 by myokono          ###   ########.fr       */
+/*   Updated: 2025/04/16 10:38:54 by yabukirento      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -88,27 +88,25 @@ int	process_input(char *input, t_shell *shell)
 static int	shell_loop(t_shell *shell)
 {
 	char	*input;
-	int		status;
 
-	status = 0;
 	while (shell->running)
 	{
 		setup_signals();
-		if (g_signal_status)
-		{
-			shell->exit_status = 128 + g_signal_status;
-			g_signal_status = 0;
-			continue ;
-		}
 		input = readline("minishell$ ");
-		if (!input)
+		if (input == NULL)
 		{
+			if (g_signal_status == SIGINT)
+			{
+				g_signal_status = 0;
+				shell->exit_status = 130;
+				continue;
+			}
 			printf("exit\n");
 			break ;
 		}
-		status = process_input(input, shell);
+		shell->exit_status = process_input(input, shell);
 	}
-	return (status);
+	return (shell->exit_status);
 }
 
 int	main(int argc, char **argv, char **envp)

--- a/srcs/signals/signals.c
+++ b/srcs/signals/signals.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   signals.c                                          :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: myokono <myokono@student.42tokyo.jp>       +#+  +:+       +#+        */
+/*   By: yabukirento <yabukirento@student.42.fr>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/12 13:52:21 by ryabuki           #+#    #+#             */
-/*   Updated: 2025/04/13 20:43:25 by myokono          ###   ########.fr       */
+/*   Updated: 2025/04/16 10:36:29 by yabukirento      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,10 +15,10 @@
 void	handle_sigint(int sig)
 {
 	(void)sig;
-	g_signal_status = 2;
+	g_signal_status = SIGINT;
 	write(STDOUT_FILENO, "\n", 1);
-	rl_on_new_line();
 	rl_replace_line("", 0);
+	rl_on_new_line();
 	rl_redisplay();
 }
 


### PR DESCRIPTION
This pull request includes several changes to the `minishell` project, focusing on signal handling improvements and code cleanup. The most significant changes involve updating author information, modifying signal handling logic, and cleaning up unused definitions.

### Author Information Updates:
* [`includes/minishell.h`](diffhunk://#diff-29c141a418b83334b1dd8ff9066c9fb218e84e274d4381095f6aecb05b8fc5daL6-R9): Updated author information to `yabukirento` and the timestamp to the latest modification date.
* [`srcs/main.c`](diffhunk://#diff-4df2027984e76b7fa6b2f2bcbdd95ba572cf926771e7c5cd68b3d7747ab782c5L6-R9): Updated author information to `yabukirento` and the timestamp to the latest modification date.
* [`srcs/signals/signals.c`](diffhunk://#diff-077ba7d0022629545541fbe5f844a2d69f8098d8d4890d4f1e77955caff7ff3aL6-R9): Updated author information to `yabukirento` and the timestamp to the latest modification date.

### Signal Handling Improvements:
* [`srcs/main.c`](diffhunk://#diff-4df2027984e76b7fa6b2f2bcbdd95ba572cf926771e7c5cd68b3d7747ab782c5L91-R109): Improved signal handling in the `shell_loop` function by setting `shell->exit_status` to 130 when `SIGINT` is received and ensuring proper cleanup when `readline` returns `NULL`.
* [`srcs/signals/signals.c`](diffhunk://#diff-077ba7d0022629545541fbe5f844a2d69f8098d8d4890d4f1e77955caff7ff3aL18-R21): Changed the signal handling logic in `handle_sigint` to set `g_signal_status` to `SIGINT` instead of a hardcoded value and adjusted the order of `readline` functions for better readability.

### Code Cleanup:
* [`includes/minishell.h`](diffhunk://#diff-29c141a418b83334b1dd8ff9066c9fb218e84e274d4381095f6aecb05b8fc5daL37-L38): Removed unused definitions `EXIT_SUCCESS` and `EXIT_FAILURE`.