### PR TITLE
exit にnumeric以外の変数が入った時の処理をbashに合わせました

### DIFF
--- a/srcs/builtins/exit.c
+++ b/srcs/builtins/exit.c
@@ -6,7 +6,7 @@
 /*   By: yabukirento <yabukirento@student.42.fr>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/05 11:20:33 by myokono           #+#    #+#             */
-/*   Updated: 2025/04/16 14:28:05 by yabukirento      ###   ########.fr       */
+/*   Updated: 2025/04/16 17:47:06 by yabukirento      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -80,8 +80,7 @@ static int	numeric_error(t_command *cmd, t_shell *shell)
 {
 	char	*error_message;
 
-	error_message = ft_strjoin(cmd->args[1], ": \
-		numeric argument required");
+	error_message = ft_strjoin(cmd->args[1], ": numeric argument required");
 	print_error(cmd->args[0], error_message);
 	free(error_message);
 	shell->running = 0;
@@ -95,7 +94,7 @@ int	builtin_exit(t_command *cmd, t_shell *shell)
 	bool		flag;
 
 	if (shell->commands->next == NULL)
-		ft_putstr_fd("exit\n", STDERR_FILENO);
+		ft_putstr_fd("exit\n", STDOUT_FILENO);
 	if (cmd->args[1] == NULL)
 	{
 		shell->running = 0;


### PR DESCRIPTION
This pull request includes changes to the `srcs/builtins/exit.c` file to fix a few issues and improve the code quality. The most important changes include updating the file's timestamp, correcting the error message formatting, and changing the output file descriptor for the exit message.

Code quality and bug fixes:

* [`srcs/builtins/exit.c`](diffhunk://#diff-79eb207e8a365fa91728b1497d593142629b1710f659a64670512f2d5c58ea5bL9-R9): Updated the timestamp in the file header to reflect the latest modification date.
* [`srcs/builtins/exit.c`](diffhunk://#diff-79eb207e8a365fa91728b1497d593142629b1710f659a64670512f2d5c58ea5bL83-R83): Corrected the formatting of the error message in the `numeric_error` function by removing unnecessary line breaks.
* [`srcs/builtins/exit.c`](diffhunk://#diff-79eb207e8a365fa91728b1497d593142629b1710f659a64670512f2d5c58ea5bL98-R97): Changed the output file descriptor from `STDERR_FILENO` to `STDOUT_FILENO` in the `builtin_exit` function to ensure the exit message is printed to the standard output.