### PR TITLE
無意味な環境変数が入力された場合に対応しました(including exit_status)

### DIFF
--- a/srcs/builtins/env.c
+++ b/srcs/builtins/env.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   env.c                                              :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: myokono <myokono@student.42tokyo.jp>       +#+  +:+       +#+        */
+/*   By: yabukirento <yabukirento@student.42.fr>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/12 12:35:26 by ryabuki           #+#    #+#             */
-/*   Updated: 2025/04/13 20:53:14 by myokono          ###   ########.fr       */
+/*   Updated: 2025/04/16 17:51:01 by yabukirento      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,10 +24,7 @@ int	builtin_env(t_command *cmd, t_shell *shell)
 	current = shell->env_list;
 	while (current)
 	{
-		ft_putstr_fd(current->key, STDOUT_FILENO);
-		ft_putstr_fd("=", STDOUT_FILENO);
-		ft_putstr_fd(current->value, STDOUT_FILENO);
-		ft_putstr_fd("\n", STDOUT_FILENO);
+		ft_fprintf2(STDOUT_FILENO, "%s=%s\n", current->key, current->value);
 		current = current->next;
 	}
 	return (SUCCESS);

--- a/srcs/executor/executor.c
+++ b/srcs/executor/executor.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   executor.c                                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: ryabuki <ryabuki@student.42.fr>            +#+  +:+       +#+        */
+/*   By: yabukirento <yabukirento@student.42.fr>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/07 19:06:57 by myokono           #+#    #+#             */
-/*   Updated: 2025/04/12 14:05:05 by ryabuki          ###   ########.fr       */
+/*   Updated: 2025/04/16 18:05:30 by yabukirento      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -64,7 +64,10 @@ static int	execute_command(t_command *cmd, t_shell *shell)
 
 int	execute_commands(t_shell *shell)
 {
-	if (!shell->commands)
+	char	**args;
+
+	args = shell->commands->args;
+	if (!shell->commands || !args || !args[0] || args[0][0] == '\0')
 		return (SUCCESS);
 	if (!shell->commands->next)
 		return (execute_command(shell->commands, shell));

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -6,7 +6,7 @@
 /*   By: yabukirento <yabukirento@student.42.fr>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/27 19:12:06 by myokono           #+#    #+#             */
-/*   Updated: 2025/04/16 15:00:13 by yabukirento      ###   ########.fr       */
+/*   Updated: 2025/04/16 18:15:17 by yabukirento      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -64,11 +64,10 @@ int	process_input(char *input, t_shell *shell)
 		return (free (input), SUCCESS);
 	add_history(input);
 	shell->tokens = tokenize(input, shell);
+	if (shell->tokens == NULL && shell->exit_status == 123)
+		return (free(input), SUCCESS);
 	if (shell->tokens == NULL || parse(shell) != SUCCESS)
-	{
-		free(input);
-		return (ERROR);
-	}
+		return (free(input), ERROR);
 	g_signal_status = execute_commands(shell);
 	last_arg = get_last_argument(shell->commands);
 	if (last_arg)

--- a/srcs/parser/env.c
+++ b/srcs/parser/env.c
@@ -6,7 +6,7 @@
 /*   By: yabukirento <yabukirento@student.42.fr>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/06 21:24:50 by myokono           #+#    #+#             */
-/*   Updated: 2025/04/16 14:56:18 by yabukirento      ###   ########.fr       */
+/*   Updated: 2025/04/16 17:53:36 by yabukirento      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -96,7 +96,7 @@ int	expand_env_var(char *input, int *i, char **result, t_shell *shell)
 		var_value = get_last_command_path(shell);
 	free(var_name);
 	if (var_value == NULL)
-		return (ERROR);
+		return (SUCCESS);
 	if (join_result(result, var_value) == false)
 		return (ERROR);
 	return (SUCCESS);

--- a/srcs/parser/lexer.c
+++ b/srcs/parser/lexer.c
@@ -3,14 +3,14 @@
 /*                                                        :::      ::::::::   */
 /*   lexer.c                                            :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: myokono <myokono@student.42tokyo.jp>       +#+  +:+       +#+        */
+/*   By: yabukirento <yabukirento@student.42.fr>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/27 12:35:52 by myokono           #+#    #+#             */
-/*   Updated: 2025/04/08 11:31:52 by myokono          ###   ########.fr       */
+/*   Updated: 2025/04/16 18:14:39 by yabukirento      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "../../includes/minishell.h"
+#include "minishell.h"
 
 int	is_space(char c)
 {
@@ -88,5 +88,7 @@ t_token	*tokenize(char *input, t_shell *shell)
 				return (free_tokens(tokens), NULL);
 		}
 	}
+	if (tokens == NULL)
+		shell->exit_status = 123;
 	return (tokens);
 }

--- a/srcs/parser/parser.c
+++ b/srcs/parser/parser.c
@@ -3,14 +3,14 @@
 /*                                                        :::      ::::::::   */
 /*   parser.c                                           :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: myokono <myokono@student.42.fr>            +#+  +:+       +#+        */
+/*   By: yabukirento <yabukirento@student.42.fr>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
-/*   Created: 2023/01/01 00:00:00 by user              #+#    #+#             */
-/*   Updated: 2025/04/12 18:28:10 by myokono          ###   ########.fr       */
+/*   Created: 2025/04/16 17:52:05 by yabukirento       #+#    #+#             */
+/*   Updated: 2025/04/16 17:52:14 by yabukirento      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "../../includes/minishell.h"
+#include "minishell.h"
 
 static int	process_token(t_token **current_token, t_command **current_cmd,
 	t_command **commands)

--- a/srcs/parser/words.c
+++ b/srcs/parser/words.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   words.c                                            :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: ryabuki <ryabuki@student.42.fr>            +#+  +:+       +#+        */
+/*   By: yabukirento <yabukirento@student.42.fr>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/06 18:10:47 by myokono           #+#    #+#             */
-/*   Updated: 2025/04/12 13:28:11 by ryabuki          ###   ########.fr       */
+/*   Updated: 2025/04/16 18:09:04 by yabukirento      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -79,13 +79,11 @@ int	process_quote_or_dollar(char *input, int *i, char **result, t_shell *shell)
 int	handle_word_token(char *input, int *i, t_token **tokens, t_shell *shell)
 {
 	char	*result;
-	int		has_content;
 	int		start_pos;
 
 	result = ft_strdup("");
 	if (result == NULL)
 		return (ERROR);
-	has_content = 0;
 	start_pos = *i;
 	while (input[*i] && !is_delimiter(input[*i]))
 	{
@@ -94,10 +92,17 @@ int	handle_word_token(char *input, int *i, t_token **tokens, t_shell *shell)
 			free(result);
 			return (ERROR);
 		}
-		has_content = 1;
 	}
-	if (has_content || ft_strlen(result) > 0 || (*i > start_pos))
-		add_token(tokens, create_token(TOKEN_WORD, result));
+	if (*i > start_pos && result[0] != '\0')
+	{
+		t_token *new_token = create_token(TOKEN_WORD, result);
+		if (!new_token)
+		{
+			free(result);
+			return (ERROR);
+		}
+		add_token(tokens, new_token);
+	}
 	else
 		free(result);
 	return (SUCCESS);


### PR DESCRIPTION
This pull request includes various updates and improvements across multiple files, primarily focusing on code simplification, bug fixes, and author information updates.

### Code Simplification and Bug Fixes:
* [`srcs/builtins/env.c`](diffhunk://#diff-ac1ecf42284eb2517700e5c47acf2e4fd9a24ae8cc64bc953342dee2f9b1864eL27-R27): Replaced multiple `ft_putstr_fd` calls with a single `ft_fprintf2` call for better readability and efficiency.
* [`srcs/executor/executor.c`](diffhunk://#diff-ab85f2c8376cece4cc4234c7fc86e185e8ca5cd1dde4cf52c37898718e76bc03L67-R70): Added additional checks for command arguments to handle empty or null values properly.
* [`srcs/main.c`](diffhunk://#diff-4df2027984e76b7fa6b2f2bcbdd95ba572cf926771e7c5cd68b3d7747ab782c5R67-R70): Improved error handling in `process_input` by adding a check for a specific exit status and simplifying the return statements.
* [`srcs/parser/env.c`](diffhunk://#diff-a8d73de4150ea70d92590cae32dd6673eb938e9bf422b67b18b813ec9e0804c6L99-R99): Changed the return value to `SUCCESS` when `var_value` is `NULL` to avoid errors.
* [`srcs/parser/lexer.c`](diffhunk://#diff-ef5415d1c89189545e1f7a1e128f6940674e90b1118dc97af84a15bdf8163ff1R91-R92): Set a specific exit status when no tokens are generated to indicate a particular error state.
* [`srcs/parser/words.c`](diffhunk://#diff-6a81afef883e95a7b011993426a471ed43ad0de2ced843a39a4cbfe33ea0705bL97-R105): Removed unused variables and added null checks for token creation to prevent potential crashes.

### Author Information Updates:
* Updated author information in the headers of several files to reflect changes in authorship. [[1]](diffhunk://#diff-ac1ecf42284eb2517700e5c47acf2e4fd9a24ae8cc64bc953342dee2f9b1864eL6-R9) [[2]](diffhunk://#diff-ab85f2c8376cece4cc4234c7fc86e185e8ca5cd1dde4cf52c37898718e76bc03L6-R9) [[3]](diffhunk://#diff-4df2027984e76b7fa6b2f2bcbdd95ba572cf926771e7c5cd68b3d7747ab782c5L9-R9) [[4]](diffhunk://#diff-a8d73de4150ea70d92590cae32dd6673eb938e9bf422b67b18b813ec9e0804c6L9-R9) [[5]](diffhunk://#diff-ef5415d1c89189545e1f7a1e128f6940674e90b1118dc97af84a15bdf8163ff1L6-R13) [[6]](diffhunk://#diff-9f60c271c563339e133e729496a6abbe5622d6e17a0088c5fd5bd3862b72783cL6-R13) [[7]](diffhunk://#diff-6a81afef883e95a7b011993426a471ed43ad0de2ced843a39a4cbfe33ea0705bL6-R9)