### PR TITLE
export =Tなど、keyがないexportの時のエラーメッセージをbashと合わせました

### DIFF
--- a/srcs/builtins/export.c
+++ b/srcs/builtins/export.c
@@ -6,7 +6,7 @@
 /*   By: yabukirento <yabukirento@student.42.fr>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/07 02:09:14 by myokono           #+#    #+#             */
-/*   Updated: 2025/04/16 14:27:49 by yabukirento      ###   ########.fr       */
+/*   Updated: 2025/04/16 18:32:20 by yabukirento      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -44,7 +44,7 @@ static int	export_with_equal(char *arg, char *equals_pos, t_shell *shell)
 	value = ft_strdup(equals_pos + 1);
 	if (!is_valid_identifier(key))
 	{
-		msg = ft_strjoin(key, ": not a valid identifier");
+		msg = ft_strjoin(arg, ": not a valid identifier");
 		if (msg == NULL)
 			return (ERROR);
 		print_error("export", msg);


### PR DESCRIPTION
This pull request includes a small but important change to the `srcs/builtins/export.c` file. The change updates the error message to include the full argument instead of just the key when an invalid identifier is encountered.

* [`srcs/builtins/export.c`](diffhunk://#diff-3a51656c4103f9e30ff7d3d4190a97a2bfded04a250e5e3ba714a88a09c052ceL47-R47): Modified the `export_with_equal` function to use the full argument in the error message instead of just the key.