### PR TITLE
カレントディレクトリが消えてもpwd, cd ..がbash同様に反応するようにしました

### DIFF
--- a/srcs/builtins/cd.c
+++ b/srcs/builtins/cd.c
@@ -3,25 +3,40 @@
 /*                                                        :::      ::::::::   */
 /*   cd.c                                               :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: myokono <myokono@student.42.fr>            +#+  +:+       +#+        */
+/*   By: yabukirento <yabukirento@student.42.fr>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/27 12:25:47 by myokono           #+#    #+#             */
-/*   Updated: 2025/04/12 18:00:32 by myokono          ###   ########.fr       */
+/*   Updated: 2025/04/16 19:07:51 by yabukirento      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "../../includes/minishell.h"
+#include "minishell.h"
 
 static int	update_pwd_env(t_shell *shell, char *old_pwd)
 {
 	char	current_pwd[PATH_MAX];
+	char	*fallback_pwd;
+	char	*logical_pwd;
 
 	if (getcwd(current_pwd, PATH_MAX) == NULL)
 	{
-		system_error("getcwd");
-		return (ERROR);
+		fallback_pwd = get_env_value(shell->env_list, "PWD");
+		if (!fallback_pwd)
+		{
+			system_error("getcwd and no PWD fallback");
+			return (ERROR);
+		}
+		logical_pwd = ft_strjoin(fallback_pwd, "/..");
+		if (!logical_pwd)
+		{
+			system_error("ft_strjoin");
+			return (ERROR);
+		}
+		add_env_node(&shell->env_list, "PWD", logical_pwd);
+		free(logical_pwd);
 	}
-	add_env_node(&shell->env_list, "PWD", current_pwd);
+	else
+		add_env_node(&shell->env_list, "PWD", current_pwd);
 	if (old_pwd)
 		add_env_node(&shell->env_list, "OLDPWD", old_pwd);
 	update_env_array(shell);
@@ -41,7 +56,7 @@ int	builtin_cd(t_command *cmd, t_shell *shell)
 	if (cmd->args[1] && cmd->args[2])
 		return (error_message("cd: too many arguments"), ERROR);
 	if (getcwd(old_pwd, PATH_MAX) == NULL)
-		return (system_error("getcwd"), ERROR);
+		old_pwd[0] = '\0';
 	if (!cmd->args[1])
 	{
 		path = get_env_value(shell->env_list, "HOME");
@@ -55,7 +70,8 @@ int	builtin_cd(t_command *cmd, t_shell *shell)
 		system_error(path);
 		return (ERROR);
 	}
-	if (update_pwd_env(shell, old_pwd) != SUCCESS)
+	if (update_pwd_env(shell, old_pwd[0] ? old_pwd : NULL) != SUCCESS)
 		return (system_error("update_pwd_env"), ERROR);
+
 	return (SUCCESS);
 }

--- a/srcs/builtins/pwd.c
+++ b/srcs/builtins/pwd.c
@@ -3,27 +3,33 @@
 /*                                                        :::      ::::::::   */
 /*   pwd.c                                              :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: myokono <myokono@student.42tokyo.jp>       +#+  +:+       +#+        */
+/*   By: yabukirento <yabukirento@student.42.fr>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/05 12:31:02 by myokono           #+#    #+#             */
-/*   Updated: 2025/04/07 17:04:36 by myokono          ###   ########.fr       */
+/*   Updated: 2025/04/16 19:02:21 by yabukirento      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "../../includes/minishell.h"
+#include "minishell.h"
+
+static int	print_dir(char *path)
+{
+	ft_fprintf1(STDOUT_FILENO, "%s\n", path);
+	return (SUCCESS);
+}
 
 int	builtin_pwd(t_command *cmd, t_shell *shell)
 {
 	char	current_dir[PATH_MAX];
+	char	*fallback_pwd;
 
 	(void)cmd;
 	(void)shell;
-	if (getcwd(current_dir, PATH_MAX) == NULL)
-	{
-		system_error("pwd");
-		return (ERROR);
-	}
-	ft_putstr_fd(current_dir, STDOUT_FILENO);
-	ft_putstr_fd("\n", STDOUT_FILENO);
-	return (SUCCESS);
+	if (getcwd(current_dir, PATH_MAX) != NULL)
+		return (print_dir(current_dir));
+	fallback_pwd = get_env_value(shell->env_list, "PWD");
+	if (fallback_pwd != NULL)
+		return (print_dir(fallback_pwd));
+	system_error("pwd");
+	return (ERROR);
 }


### PR DESCRIPTION
This pull request includes changes to improve error handling and fallback mechanisms in the `cd` and `pwd` built-in commands in the `minishell` project. The changes involve updating the environment variables correctly and providing fallback values when necessary.

Improvements to `cd` command:

* Updated the author information in the file header comments.
* Changed the include directive from `../../includes/minishell.h` to `minishell.h`.
* Enhanced the `update_pwd_env` function to use a fallback value for `PWD` if `getcwd` fails.
* Modified `builtin_cd` to handle cases where `getcwd` fails by setting `old_pwd` to an empty string instead of returning an error.
* Updated `builtin_cd` to pass `NULL` to `update_pwd_env` if `old_pwd` is empty.

Improvements to `pwd` command:

* Updated the author information in the file header comments.
* Changed the include directive from `../../includes/minishell.h` to `minishell.h`.
* Added a new `print_dir` function to simplify printing the directory path.
* Enhanced the `builtin_pwd` function to use a fallback value for `PWD` if `getcwd` fails.