### PR TITLE
integred of symbolic link

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,12 @@ minishell_tester
 .vscode
 path/
 test
+tmp
+*.o
+*.out
+*.exe
+*.dSYM
+*.dSYM/
+*.exe.stackdump
+mylink
+link

--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@
 #                                                         :::      ::::::::    #
 #    Makefile                                           :+:      :+:    :+:    #
 #                                                     +:+ +:+         +:+      #
-#    By: myokono <myokono@student.42.fr>            +#+  +:+       +#+         #
+#    By: yabukirento <yabukirento@student.42.fr>    +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2023/01/01 00:00:00 by user              #+#    #+#              #
-#    Updated: 2025/04/13 17:39:02 by myokono          ###   ########.fr        #
+#    Updated: 2025/04/16 20:40:25 by yabukirento      ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -53,6 +53,7 @@ SRCS = $(SRCS_DIR)/main.c \
 	$(EXECUTOR_DIR)/setup_redirects.c \
 	$(BUILTINS_DIR)/echo.c \
 	$(BUILTINS_DIR)/cd.c \
+	$(BUILTINS_DIR)/cd_simplify_path.c \
 	$(BUILTINS_DIR)/pwd.c \
 	$(BUILTINS_DIR)/export.c \
 	$(BUILTINS_DIR)/export_sort.c \

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,7 +6,7 @@
 /*   By: yabukirento <yabukirento@student.42.fr>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/01 00:00:00 by user              #+#    #+#             */
-/*   Updated: 2025/04/16 14:53:18 by yabukirento      ###   ########.fr       */
+/*   Updated: 2025/04/16 20:41:02 by yabukirento      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -155,6 +155,7 @@ bool		is_valid_identifier(char *key);
 int			print_sorted_env(t_env *env_list, int fd);
 int			builtin_env(t_command *cmd, t_shell *shell);
 int			builtin_exit(t_command *cmd, t_shell *shell);
+char		*simplify_path(const char *path);
 
 /* signal*/
 void		setup_signals(void);

--- a/srcs/builtins/cd_simplify_path.c
+++ b/srcs/builtins/cd_simplify_path.c
@@ -1,0 +1,65 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   cd_simplify_path.c                                 :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: yabukirento <yabukirento@student.42.fr>    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/04/16 20:39:58 by yabukirento       #+#    #+#             */
+/*   Updated: 2025/04/16 20:53:51 by yabukirento      ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "minishell.h"
+
+static void free_2d(char **array)
+{
+	int i;
+
+	i = 0;
+	if (!array)
+		return;
+	while (array[i])
+		free(array[i++]);
+	free(array);
+}
+
+static void	cut_current_dir(char *result)
+{
+	char	*last_slash;
+
+	last_slash = strrchr(result, '/');
+	if (last_slash && last_slash != result)
+		*last_slash = '\0';
+	else
+		ft_strlcpy(result, "/", sizeof(result));
+}
+
+char	*simplify_path(const char *path)
+{
+	char	**components;
+	char	result[PATH_MAX];
+	int		i;
+
+	components = ft_split(path, '/');
+	if (!components)
+		return (NULL);
+	result[0] = '/';
+	result[1] = '\0';
+	i = -1;
+	while (components[++i])
+	{
+		if (ft_strcmp(components[i], "") == 0 || ft_strcmp(components[i], ".") == 0)
+			continue;
+		if (ft_strcmp(components[i], "..") == 0)
+			cut_current_dir(result);
+		else
+		{
+			if (ft_strcmp(result, "/") != 0)
+				ft_strlcat(result, "/", sizeof(result));
+			ft_strlcat(result, components[i], sizeof(result));
+		}
+	}
+	free_2d(components);
+	return (ft_strdup(result));
+}

--- a/srcs/builtins/pwd.c
+++ b/srcs/builtins/pwd.c
@@ -6,7 +6,7 @@
 /*   By: yabukirento <yabukirento@student.42.fr>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/05 12:31:02 by myokono           #+#    #+#             */
-/*   Updated: 2025/04/16 19:02:21 by yabukirento      ###   ########.fr       */
+/*   Updated: 2025/04/16 19:39:58 by yabukirento      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -25,11 +25,11 @@ int	builtin_pwd(t_command *cmd, t_shell *shell)
 
 	(void)cmd;
 	(void)shell;
-	if (getcwd(current_dir, PATH_MAX) != NULL)
-		return (print_dir(current_dir));
 	fallback_pwd = get_env_value(shell->env_list, "PWD");
 	if (fallback_pwd != NULL)
 		return (print_dir(fallback_pwd));
+	if (getcwd(current_dir, PATH_MAX) != NULL)
+		return (print_dir(current_dir));
 	system_error("pwd");
 	return (ERROR);
 }

--- a/srcs/libft/ft_strlen.c
+++ b/srcs/libft/ft_strlen.c
@@ -6,7 +6,7 @@
 /*   By: yabukirento <yabukirento@student.42.fr>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/04/19 14:53:55 by yabukirento       #+#    #+#             */
-/*   Updated: 2024/04/19 19:33:20 by yabukirento      ###   ########.fr       */
+/*   Updated: 2025/04/16 19:59:52 by yabukirento      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,6 +18,8 @@ size_t	ft_strlen(const char *str)
 	size_t	i;
 
 	i = 0;
+	if (str == NULL)
+		return (0);
 	while (str[i] != '\0')
 	{
 		i++;


### PR DESCRIPTION
This pull request includes multiple changes to the `minishell` project, focusing on the `cd` command functionality, path simplification, and minor updates to various files. The most important changes include adding a new function to simplify paths, updating the `cd` command to handle more cases, and modifying the `pwd` command for better fallback behavior.

### Enhancements to `cd` command:

* [`srcs/builtins/cd.c`](diffhunk://#diff-7e8cc7eed5c43122bcbe47f8a48e6df0519a4d0bdc45f1ad3d34bfb9a7eece1bL9-R93): Introduced `path_join` and `cd_check_arg` functions to handle path concatenation and argument validation. Updated `builtin_cd` to use these new functions and added logic to simplify paths using the new `simplify_path` function.

### New path simplification functionality:

* [`srcs/builtins/cd_simplify_path.c`](diffhunk://#diff-820de13b8307a36dbfc30e8e28c4c1699d52194f367d5b488908b2063e9714b5R1-R65): Added a new file with the `simplify_path` function to handle path simplification by removing redundant components like `.` and `..`.
* [`includes/minishell.h`](diffhunk://#diff-29c141a418b83334b1dd8ff9066c9fb218e84e274d4381095f6aecb05b8fc5daR158): Declared the `simplify_path` function.

### Improvements to `pwd` command:

* [`srcs/builtins/pwd.c`](diffhunk://#diff-73bd75492d068ba9a465b2c743f8bbef1f346857b09560e9113dd47ef787f900L28-R32): Modified the `builtin_pwd` function to check the `PWD` environment variable first and fall back to `getcwd` if necessary.

### Minor updates and maintenance:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L6-R9): Updated author information and added the new `cd_simplify_path.c` source file to the build. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L6-R9) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R56)
* [`srcs/libft/ft_strlen.c`](diffhunk://#diff-76f162a54a3f9b17bbee7e7924f28bad88ab609570e8a36f4a9d312bff5508dcR21-R22): Updated `ft_strlen` to handle `NULL` input gracefully.

These changes collectively enhance the functionality and robustness of the `cd` and `pwd` commands in the `minishell` project.