### PR TITLE
SIGPIPEに対応したエラーメッセージを表示するようにしました

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ tmp
 *.exe.stackdump
 mylink
 link
+minishell

--- a/srcs/executor/executor_external.c
+++ b/srcs/executor/executor_external.c
@@ -6,7 +6,7 @@
 /*   By: yabukirento <yabukirento@student.42.fr>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/07 19:48:16 by myokono           #+#    #+#             */
-/*   Updated: 2025/04/16 14:25:56 by yabukirento      ###   ########.fr       */
+/*   Updated: 2025/04/16 21:24:33 by yabukirento      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -70,6 +70,8 @@ static int	wait_child_status(pid_t pid)
 			write(STDOUT_FILENO, "\n", 1);
 		else if (WTERMSIG(status) == SIGQUIT)
 			write(STDOUT_FILENO, "Quit (core dumped)\n", 19);
+		else if (WTERMSIG(status) == SIGPIPE)
+			write(STDERR_FILENO, "Broken pipe\n", 13);		
 		return (128 + WTERMSIG(status));
 	}
 	return (ERROR);

--- a/srcs/executor/pipe.c
+++ b/srcs/executor/pipe.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   pipe.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: myokono <myokono@student.42.fr>            +#+  +:+       +#+        */
+/*   By: yabukirento <yabukirento@student.42.fr>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/27 12:23:15 by myokono           #+#    #+#             */
-/*   Updated: 2025/04/12 19:11:44 by myokono          ###   ########.fr       */
+/*   Updated: 2025/04/16 21:25:02 by yabukirento      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -32,6 +32,8 @@ static int	wait_for_last_pid(pid_t last_pid)
 					write(STDOUT_FILENO, "\n", 1);
 				else if (WTERMSIG(status) == SIGQUIT)
 					write(STDOUT_FILENO, "Quit (core dumped)\n", 19);
+				else if (WTERMSIG(status) == SIGPIPE)
+					write(STDERR_FILENO, "Broken pipe\n", 13);				
 				last_status = 128 + WTERMSIG(status);
 			}
 		}


### PR DESCRIPTION
This pull request includes changes to handle the `SIGPIPE` signal in the executor module and updates to author information in the file headers. The most important changes are as follows:

Signal handling improvements:

* [`srcs/executor/executor_external.c`](diffhunk://#diff-eadb16e06bfa408c8833d0314db116c5868611b911e9c86f2ee356f08baa398dR73-R74): Added handling for the `SIGPIPE` signal in the `wait_child_status` function to write "Broken pipe" to `STDERR_FILENO`.
* [`srcs/executor/pipe.c`](diffhunk://#diff-3e38d452289736e99002c28d193ac5b7092f761d9d7c679ba0d81681f154883dR35-R36): Added handling for the `SIGPIPE` signal in the `wait_for_last_pid` function to write "Broken pipe" to `STDERR_FILENO`.

Author information updates:

* [`srcs/executor/executor_external.c`](diffhunk://#diff-eadb16e06bfa408c8833d0314db116c5868611b911e9c86f2ee356f08baa398dL9-R9): Updated author information in the file header to reflect the new maintainer.
* [`srcs/executor/pipe.c`](diffhunk://#diff-3e38d452289736e99002c28d193ac5b7092f761d9d7c679ba0d81681f154883dL6-R9): Updated author information in the file header to reflect the new maintainer.