### PR TITLE
echo <><>など、Syntax error near unexpected tokenが表示される際にりーくしないようにしました

### DIFF
--- a/srcs/parser/parser.c
+++ b/srcs/parser/parser.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   parser.c                                           :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: yabukirento <yabukirento@student.42.fr>    +#+  +:+       +#+        */
+/*   By: ryabuki <ryabuki@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/16 17:52:05 by yabukirento       #+#    #+#             */
-/*   Updated: 2025/04/16 17:52:14 by yabukirento      ###   ########.fr       */
+/*   Updated: 2025/04/17 11:38:22 by ryabuki          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -67,7 +67,9 @@ int	parse(t_shell *shell)
 		{
 			free_commands(cur_cmd);
 			free_commands(shell->commands);
+			free_tokens(shell->tokens);
 			shell->commands = NULL;
+			shell->tokens = NULL;
 			return (ERROR);
 		}
 	}

--- a/srcs/parser/redirect_utils.c
+++ b/srcs/parser/redirect_utils.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   redirect_utils.c                                   :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: yabukirento <yabukirento@student.42.fr>    +#+  +:+       +#+        */
+/*   By: ryabuki <ryabuki@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/08 14:30:00 by yabukirento       #+#    #+#             */
-/*   Updated: 2025/04/16 21:52:21 by yabukirento      ###   ########.fr       */
+/*   Updated: 2025/04/17 11:35:11 by ryabuki          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,10 +16,16 @@ t_token	*process_redirect_tokens(t_token **tokens, t_token_type type)
 {
 	t_token	*redirect_token;
 	t_token	*filename_token;
+	char	*tmp_value;
 
-	redirect_token = create_token(type, ft_strdup((*tokens)->value));
+	tmp_value = ft_strdup((*tokens)->value);
+	if (tmp_value == NULL)
+		return (NULL);
+	redirect_token = create_token(type, tmp_value);
+	if (redirect_token == NULL)
+		return (free(tmp_value), NULL);
 	*tokens = (*tokens)->next;
-	if (!*tokens || (*tokens)->type != TOKEN_WORD)
+	if (!(*tokens) || (*tokens)->type != TOKEN_WORD)
 	{
 		free_tokens(redirect_token);
 		error_message("Syntax error near unexpected token");


### PR DESCRIPTION
This pull request includes updates to the `parser` module, focusing on improving memory management and error handling. It also includes updates to author metadata in the file headers. Below is a summary of the most important changes:

### Memory Management Improvements:

* [`srcs/parser/parser.c`](diffhunk://#diff-9f60c271c563339e133e729496a6abbe5622d6e17a0088c5fd5bd3862b72783cR70-R72): Added a call to `free_tokens` and set `shell->tokens` to `NULL` in the `parse` function to ensure proper cleanup of token memory in error cases.

* [`srcs/parser/redirect_utils.c`](diffhunk://#diff-42bbfc2768a05419a53bd2b9210a6a88a399e3693f96c4614dee812ff0c40d30R19-R28): Introduced a temporary variable `tmp_value` to safely handle memory allocation for token values in `process_redirect_tokens`. Added checks for `NULL` and ensured proper cleanup in case of allocation failures.

### File Header Updates:

* Updated the author metadata in the headers of `srcs/parser/parser.c` and `srcs/parser/redirect_utils.c` to reflect a change in the author's name and timestamp. [[1]](diffhunk://#diff-9f60c271c563339e133e729496a6abbe5622d6e17a0088c5fd5bd3862b72783cL6-R9) [[2]](diffhunk://#diff-42bbfc2768a05419a53bd2b9210a6a88a399e3693f96c4614dee812ff0c40d30L6-R9)