### PR TITLE
どこで抜けてもReadlineの内容が確実にフリーされるように修正しました

### DIFF
--- a/srcs/main.c
+++ b/srcs/main.c
@@ -6,7 +6,7 @@
 /*   By: ryabuki <ryabuki@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/27 19:12:06 by myokono           #+#    #+#             */
-/*   Updated: 2025/04/17 10:50:24 by ryabuki          ###   ########.fr       */
+/*   Updated: 2025/04/17 12:03:32 by ryabuki          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -60,13 +60,13 @@ int	process_input(char *input, t_shell *shell)
 	char	*last_arg;
 
 	if (!input || ft_strlen(input) == 0)
-		return (free (input), SUCCESS);
+		return (SUCCESS);
 	add_history(input);
 	shell->tokens = tokenize(input, shell);
 	if (shell->tokens == NULL && shell->exit_status == NO_TOKEN)
-		return (free(input), SUCCESS);
+		return (SUCCESS);
 	if (shell->tokens == NULL || parse(shell) != SUCCESS)
-		return (free(input), ERROR);
+		return (ERROR);
 	g_signal_status = execute_commands(shell);
 	last_arg = get_last_argument(shell->commands);
 	if (last_arg)
@@ -75,11 +75,6 @@ int	process_input(char *input, t_shell *shell)
 		update_env_array(shell);
 		free(last_arg);
 	}
-	free_tokens(shell->tokens);
-	shell->tokens = NULL;
-	free_commands(shell->commands);
-	shell->commands = NULL;
-	free(input);
 	return (g_signal_status);
 }
 
@@ -97,6 +92,11 @@ static int	shell_loop(t_shell *shell)
 			break ;
 		}		
 		g_signal_status = process_input(input, shell);
+		free_tokens(shell->tokens);
+		shell->tokens = NULL;
+		free_commands(shell->commands);
+		shell->commands = NULL;
+		free(input);
 	}
 	return (g_signal_status);
 }

--- a/srcs/parser/parser.c
+++ b/srcs/parser/parser.c
@@ -6,7 +6,7 @@
 /*   By: ryabuki <ryabuki@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/16 17:52:05 by yabukirento       #+#    #+#             */
-/*   Updated: 2025/04/17 11:38:22 by ryabuki          ###   ########.fr       */
+/*   Updated: 2025/04/17 12:02:01 by ryabuki          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -66,10 +66,10 @@ int	parse(t_shell *shell)
 		if (process_token(&cur_token, &cur_cmd, &shell->commands) == ERROR)
 		{
 			free_commands(cur_cmd);
-			free_commands(shell->commands);
-			free_tokens(shell->tokens);
-			shell->commands = NULL;
-			shell->tokens = NULL;
+			// free_commands(shell->commands);
+			// free_tokens(shell->tokens);
+			// shell->commands = NULL;
+			// shell->tokens = NULL;
 			return (ERROR);
 		}
 	}


### PR DESCRIPTION
This pull request refactors memory management in the shell application by centralizing cleanup operations for tokens, commands, and input strings. The changes aim to improve code maintainability and reduce redundancy by moving cleanup logic from multiple locations to a single point in the `shell_loop` function. Additionally, some cleanup calls in the `parse` function have been commented out.

### Centralized memory management:
* Moved cleanup logic for `tokens`, `commands`, and `input` from `process_input` to `shell_loop`, ensuring all memory is freed in one place. (`srcs/main.c`: [[1]](diffhunk://#diff-4df2027984e76b7fa6b2f2bcbdd95ba572cf926771e7c5cd68b3d7747ab782c5L78-L82) [[2]](diffhunk://#diff-4df2027984e76b7fa6b2f2bcbdd95ba572cf926771e7c5cd68b3d7747ab782c5R95-R99)

### Code simplification:
* Removed redundant `free` calls for `input` in `process_input`, as cleanup is now handled in `shell_loop`. (`srcs/main.c`: [srcs/main.cL63-R69](diffhunk://#diff-4df2027984e76b7fa6b2f2bcbdd95ba572cf926771e7c5cd68b3d7747ab782c5L63-R69))
* Commented out cleanup code in the `parse` function, as it may no longer be necessary due to the centralized cleanup in `shell_loop`. (`srcs/parser/parser.c`: [srcs/parser/parser.cL69-R72](diffhunk://#diff-9f60c271c563339e133e729496a6abbe5622d6e17a0088c5fd5bd3862b72783cL69-R72))