### PR TITLE
norm

### DIFF
--- a/srcs/gnl/srcs/get_next_line.c
+++ b/srcs/gnl/srcs/get_next_line.c
@@ -6,7 +6,7 @@
 /*   By: ryabuki <ryabuki@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/19 19:05:04 by yabukirento       #+#    #+#             */
-/*   Updated: 2025/04/17 13:51:15 by ryabuki          ###   ########.fr       */
+/*   Updated: 2025/04/17 14:02:16 by ryabuki          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -35,11 +35,7 @@ static char	*read_to_newline(int fd, char **saved, char *buffer)
 		if (ft_strchr(*saved, '\n'))
 			break ;
 	}
-	if (*saved == NULL)
-		return (NULL);
-	if (bytes_read < 0)
-		return (free(*saved), NULL);
-	if (bytes_read == 0 && ft_strlen(*saved) == 0)
+	if ((bytes_read == 0 && ft_strlen(*saved) == 0) || bytes_read < 0)
 		return (free(*saved), NULL);
 	return (*saved);
 }


### PR DESCRIPTION
This pull request refines the `read_to_newline` function in `get_next_line.c` to simplify its logic and improve readability. The most notable change is the consolidation of conditions for returning `NULL` when `bytes_read` is zero or negative.

### Refinements to `read_to_newline` logic:
* Simplified the condition for returning `NULL` by merging checks for `bytes_read` being zero with an empty `*saved` and `bytes_read` being negative into a single condition. This removes redundant checks and improves code clarity. (`srcs/gnl/srcs/get_next_line.c`, [srcs/gnl/srcs/get_next_line.cL38-R38](diffhunk://#diff-c92d37f79491fe0532e0a5e2fda5eb5dde3e5d19eaa77689efab09fca26fd05aL38-R38))

### Minor updates:
* Updated the file header's "Updated" timestamp to reflect the latest changes. (`srcs/gnl/srcs/get_next_line.c`, [srcs/gnl/srcs/get_next_line.cL9-R9](diffhunk://#diff-c92d37f79491fe0532e0a5e2fda5eb5dde3e5d19eaa77689efab09fca26fd05aL9-R9))